### PR TITLE
feat: 필터와 드롭다운 컨포넌트

### DIFF
--- a/app/example/page.tsx
+++ b/app/example/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+import Filter from '../../src/components/common/filter';
+
+export default function example() {
+  const options = ['아무것도', '하기', '싫다!'];
+  return (
+    <div className="flex justify-between p-4">
+      <div>
+        <Filter type="Left" options={options} />
+      </div>
+      <div>
+        <Filter type="Right" options={options} />
+      </div>
+    </div>
+  );
+}

--- a/app/example/page.tsx
+++ b/app/example/page.tsx
@@ -6,10 +6,10 @@ export default function example() {
   return (
     <div className="flex justify-between p-4">
       <div>
-        <Filter type="Left" options={options} />
+        <Filter version="Left" options={options} />
       </div>
       <div>
-        <Filter type="Right" options={options} />
+        <Filter version="Right" options={options} />
       </div>
     </div>
   );

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -1,0 +1,27 @@
+export default function Dropdown({
+  options,
+  onSelect,
+  type,
+}: {
+  options: string[];
+  onSelect: (option: string) => void;
+  type: 'Left' | 'Right';
+}) {
+  return (
+    <div
+      className={`absolute mt-2 w-full rounded border border-gray-300 bg-white shadow-lg ${
+        type === 'Left' ? 'left-0' : 'right-0'
+      }`}
+    >
+      {options.map((option) => (
+        <button
+          key={option}
+          onClick={() => onSelect(option)}
+          className="block w-full px-4 py-2 text-left hover:bg-gray-100"
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -2,22 +2,30 @@ export default function Dropdown({
   options,
   onSelect,
   type,
+  selectedOption,
 }: {
   options: string[];
   onSelect: (option: string) => void;
-  type: 'Left' | 'Right';
+  type: 'Input' | 'Filter'; // width의 차이로 편의상 타입명을 지정하였습니다 기능과는 관련이 없습니다
+  selectedOption: string;
 }) {
+  const handleSelect = (option: string) => {
+    onSelect(option);
+  };
+
   return (
     <div
-      className={`absolute mt-2 w-full rounded border border-gray-300 bg-white shadow-lg ${
-        type === 'Left' ? 'left-0' : 'right-0'
+      className={`absolute mt-2 rounded-xl bg-white shadow-lg ${
+        type === 'Input' ? 'w-[472px]' : 'w-[110px]'
       }`}
     >
       {options.map((option) => (
         <button
           key={option}
-          onClick={() => onSelect(option)}
-          className="block w-full px-4 py-2 text-left hover:bg-gray-100"
+          onClick={() => handleSelect(option)}
+          className={`m-1 block rounded-xl px-4 py-2 text-left hover:bg-secondary-200 ${
+            type === 'Input' ? 'w-[464px]' : 'w-[102px]'
+          } ${selectedOption === option ? 'bg-orange-100' : ''}`}
         >
           {option}
         </button>

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -1,14 +1,21 @@
+import { type ComponentPropsWithoutRef } from 'react';
+
+interface dropdownProps
+  extends Omit<ComponentPropsWithoutRef<'button'>, 'onClick' | 'onSelect'> {
+  onClick?: (option: string) => void;
+  options: string[];
+  onSelect: (option: string) => void;
+  version: 'Input' | 'Filter'; // width의 차이로 편의상 타입명을 지정하였습니다 기능과는 관련이 없습니다
+  selectedOption: string;
+}
+
 export default function Dropdown({
   options,
   onSelect,
-  type,
+  version,
   selectedOption,
-}: {
-  options: string[];
-  onSelect: (option: string) => void;
-  type: 'Input' | 'Filter'; // width의 차이로 편의상 타입명을 지정하였습니다 기능과는 관련이 없습니다
-  selectedOption: string;
-}) {
+  ...rest
+}: dropdownProps) {
   const handleSelect = (option: string) => {
     onSelect(option);
   };
@@ -16,15 +23,16 @@ export default function Dropdown({
   return (
     <div
       className={`absolute mt-2 rounded-xl bg-white shadow-lg ${
-        type === 'Input' ? 'w-[472px]' : 'w-[110px]'
+        version === 'Input' ? 'w-[472px]' : 'w-[110px]'
       }`}
     >
       {options.map((option) => (
         <button
+          {...rest}
           key={option}
           onClick={() => handleSelect(option)}
           className={`m-1 block rounded-xl px-4 py-2 text-left hover:bg-secondary-200 ${
-            type === 'Input' ? 'w-[464px]' : 'w-[102px]'
+            version === 'Input' ? 'w-[464px]' : 'w-[102px]'
           } ${selectedOption === option ? 'bg-orange-100' : ''}`}
         >
           {option}

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import Dropdown from '~/src/components/common/Dropdown';
+import Dropdown from '~/src/components/common/dropdown';
 
 export default function Filter({
   type,
@@ -19,15 +19,22 @@ export default function Filter({
   };
 
   return (
-    <div className="relative h-9 w-[110px] lg:h-10 lg:w-[120px]">
+    <div className="relative">
       <button
         onClick={toggleDropdown}
-        className="w-full rounded border border-gray-300 bg-white px-4 py-2 hover:bg-gray-100"
+        className={`flex h-8 w-[110px] rounded-xl border-[2px] border-secondary-100 bg-white px-3 py-[6px] text-secondary-800 hover:bg-secondary-50 sm:h-9 sm:w-[120px] sm:py-2 ${
+          type === 'Right'
+            ? 'justify-between active:border-none active:bg-secondary-900 active:text-secondary-50'
+            : 'gap-[10px]'
+        } ${type === 'Left' ? 'h-9 w-9 px-[6px] py-[6px] sm:h-auto sm:w-auto sm:px-3 sm:py-2' : ''}`}
       >
         <div className={`${type === 'Left' ? 'text-left' : 'hidden'}`}>왼</div>
-        {selected}
+        <div className={`${type === 'Left' ? 'hidden sm:block' : ''}`}>
+          {selected}
+        </div>
         <div className={`${type === 'Right' ? 'text-left' : 'hidden'}`}>오</div>
       </button>
+
       {isOpen && (
         <Dropdown options={options} onSelect={selectOption} type={type} />
       )}

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -13,7 +13,9 @@ interface filterProps extends React.ComponentPropsWithoutRef<'button'> {
 }
 
 export default function Filter({ version, options, ...rest }: filterProps) {
-  const [selected, setSelected] = useState('Filter');
+  const [selected, setSelected] = useState(
+    options.length > 0 ? options[0] : '',
+  );
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleDropdown = () => setIsOpen(!isOpen);

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -2,16 +2,17 @@ import { useState } from 'react';
 import Image from 'next/image';
 
 import DownCaret from '~/src/assets/icons/caret-down.svg?url';
+import DownCaretInverse from '~/src/assets/icons/caret-down-inverse.svg?url';
 import SortIcon from '~/src/assets/icons/sort.svg?url';
 import Dropdown from '~/src/components/common/dropdown';
+import { cn } from '~/src/utils/class-name';
 
-export default function Filter({
-  type,
-  options,
-}: {
-  type: 'Left' | 'Right'; //기능에서 별다른 차이가 없어보이지만 아이콘이 좌우로 가는게 차이가 있어보여 2가지 타입을 지정했습니다
+interface filterProps extends React.ComponentPropsWithoutRef<'button'> {
+  version: 'Left' | 'Right'; //기능에서 별다른 차이가 없어보이지만 아이콘이 좌우로 가는게 차이가 있어보여 2가지 타입을 지정했습니다
   options: string[];
-}) {
+}
+
+export default function Filter({ version, options, ...rest }: filterProps) {
   const [selected, setSelected] = useState('Filter');
   const [isOpen, setIsOpen] = useState(false);
 
@@ -24,23 +25,37 @@ export default function Filter({
   return (
     <div className="relative">
       <button
+        {...rest}
         onClick={toggleDropdown}
-        className={`flex h-9 rounded-xl border-[2px] border-secondary-100 bg-white px-3 py-[6px] text-secondary-800 hover:bg-secondary-50 sm:h-10 sm:py-2 ${type === 'Right' ? 'justify-between active:border-none active:bg-secondary-900 active:text-secondary-50' : 'gap-[10px] align-middle'} ${type === 'Left' ? 'h-9 w-9 px-[6px] py-[6px] sm:w-[120px] sm:px-3 sm:py-2' : 'w-[110px]'}`}
+        className={cn(
+          'flex h-9 rounded-xl border-[2px] border-secondary-100 bg-white px-3 py-[6px] text-secondary-800',
+          'sm:h-10 sm:py-2',
+          version === 'Right' &&
+            (isOpen
+              ? 'justify-between border-none bg-secondary-900 text-secondary-50'
+              : 'justify-between hover:bg-secondary-50'),
+          version === 'Left' &&
+            'h-9 w-9 px-[6px] py-[6px] hover:bg-secondary-50 sm:w-[120px] sm:gap-[10px] sm:px-3 sm:py-2',
+          version !== 'Left' && 'w-[110px]',
+        )}
       >
         <Image
-          className={`${type === 'Left' ? 'text-left' : 'hidden'}`}
           src={SortIcon}
-          alt="sort"
+          alt="sortIcon"
           width={24}
           height={24}
+          className={`${version === 'Left' ? 'text-left' : 'hidden'}`}
         />
-        <div className={`${type === 'Left' ? 'hidden sm:block' : ''}`}>
+
+        <div
+          className={`flex items-center text-sm ${version === 'Left' ? 'hidden sm:block' : ''}`}
+        >
           {selected}
         </div>
         <Image
-          src={DownCaret}
-          alt="DownCaret"
-          className={`${type === 'Right' ? 'text-left' : 'hidden'}`}
+          src={isOpen ? DownCaretInverse : DownCaret}
+          alt="Caret Icon"
+          className={version === 'Right' ? 'text-left' : 'hidden'}
           width={24}
           height={24}
         />
@@ -50,7 +65,7 @@ export default function Filter({
         <Dropdown
           options={options}
           onSelect={selectOption}
-          type="Filter"
+          version="Filter"
           selectedOption={selected}
         />
       )}

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+import Dropdown from '~/src/components/common/Dropdown';
+
+export default function Filter({
+  type,
+  options,
+}: {
+  type: 'Left' | 'Right'; //기능에서 별다른 차이가 없어보이지만 아이콘이 좌우로 가는게 차이가 있어보여 2가지 타입을 지정했습니다
+  options: string[];
+}) {
+  const [selected, setSelected] = useState('Filter');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleDropdown = () => setIsOpen(!isOpen);
+  const selectOption = (option: string) => {
+    setSelected(option);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative h-9 w-[110px] lg:h-10 lg:w-[120px]">
+      <button
+        onClick={toggleDropdown}
+        className="w-full rounded border border-gray-300 bg-white px-4 py-2 hover:bg-gray-100"
+      >
+        <div className={`${type === 'Left' ? 'text-left' : 'hidden'}`}>왼</div>
+        {selected}
+        <div className={`${type === 'Right' ? 'text-left' : 'hidden'}`}>오</div>
+      </button>
+      {isOpen && (
+        <Dropdown options={options} onSelect={selectOption} type={type} />
+      )}
+    </div>
+  );
+}

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
+import Image from 'next/image';
 
+import DownCaret from '~/src/assets/icons/caret-down.svg?url';
+import SortIcon from '~/src/assets/icons/sort.svg?url';
 import Dropdown from '~/src/components/common/dropdown';
 
 export default function Filter({
@@ -22,21 +25,34 @@ export default function Filter({
     <div className="relative">
       <button
         onClick={toggleDropdown}
-        className={`flex h-8 w-[110px] rounded-xl border-[2px] border-secondary-100 bg-white px-3 py-[6px] text-secondary-800 hover:bg-secondary-50 sm:h-9 sm:w-[120px] sm:py-2 ${
-          type === 'Right'
-            ? 'justify-between active:border-none active:bg-secondary-900 active:text-secondary-50'
-            : 'gap-[10px]'
-        } ${type === 'Left' ? 'h-9 w-9 px-[6px] py-[6px] sm:h-auto sm:w-auto sm:px-3 sm:py-2' : ''}`}
+        className={`flex h-9 rounded-xl border-[2px] border-secondary-100 bg-white px-3 py-[6px] text-secondary-800 hover:bg-secondary-50 sm:h-10 sm:py-2 ${type === 'Right' ? 'justify-between active:border-none active:bg-secondary-900 active:text-secondary-50' : 'gap-[10px] align-middle'} ${type === 'Left' ? 'h-9 w-9 px-[6px] py-[6px] sm:w-[120px] sm:px-3 sm:py-2' : 'w-[110px]'}`}
       >
-        <div className={`${type === 'Left' ? 'text-left' : 'hidden'}`}>왼</div>
+        <Image
+          className={`${type === 'Left' ? 'text-left' : 'hidden'}`}
+          src={SortIcon}
+          alt="sort"
+          width={24}
+          height={24}
+        />
         <div className={`${type === 'Left' ? 'hidden sm:block' : ''}`}>
           {selected}
         </div>
-        <div className={`${type === 'Right' ? 'text-left' : 'hidden'}`}>오</div>
+        <Image
+          src={DownCaret}
+          alt="DownCaret"
+          className={`${type === 'Right' ? 'text-left' : 'hidden'}`}
+          width={24}
+          height={24}
+        />
       </button>
 
       {isOpen && (
-        <Dropdown options={options} onSelect={selectOption} type={type} />
+        <Dropdown
+          options={options}
+          onSelect={selectOption}
+          type="Filter"
+          selectedOption={selected}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- 필터와 드롭다운 컨포넌트에 타입을 추가하여 상황별로 쓸 수 있게 하려 했습니다.

## 🎉 변경 사항

- 필터의 타입은 Left와 Right로 지정했고 이는 단순히 아이콘이 왼쪽, 오른쪽에 배치되어 있어서 이름을 지었습니다.
- 드롭다운의 타입은 기능이랄것도 없이 width 차이가 있어서 단순하게 어떤 박스 밑에 있는지에 따라 Filter와 Input으로 지정하였습니다. 

## 이슈

- 반응형으로 active를 구현하라고도 피그마에 나와있지만 쓰임을 완벽히 파악하지 못해서 일부 구현만 했습니다. 추후에 수정이 필요할것 같습니다.  
  => active는 드롭다운이 열릴때 서식하게 하여 보완하였습니다

- 아무래도 하나의 컨포넌트 내에서 다 할려고 해서 가독성이 떨어지고 효율성을 높이기 위해 추가적으로 수정해야 할 것 같습니다.
  => 확장성을 넓히기 위해 둘다 button의 Props를 추가하였지만 dropdown은 onclick과 onselect 모두 (string)=>void형식으로 변환했습니다.
  => 필터의 초기 값은 드롭다운의 첫번째 요소가 나오게 하고 만일 없으면 비어있게 하였습니다.

## 🙏 여기는 꼭 봐주세요!
![ani2](https://github.com/user-attachments/assets/21783859-8059-4074-8f04-f94e195c172e)

