### PR TITLE
필터와 드롭다운 반응형 개선

### DIFF
--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -7,7 +7,7 @@ interface dropdownProps
   onClick?: (option: string) => void;
   options: string[];
   onSelect: (option: string) => void;
-  version: 'Input' | 'Filter'; // width의 차이로 편의상 타입명을 지정하였습니다 기능과는 관련이 없습니다
+  version: 'Login' | 'Filter'; // width의 차이로 편의상 타입명을 지정하였습니다 기능과는 관련이 없습니다
   selectedOption: string;
 }
 
@@ -26,7 +26,7 @@ export default function Dropdown({
     <div
       className={cn(
         'absolute mt-2 rounded-xl bg-white shadow-lg',
-        version === 'Input' ? 'w-[472px]' : 'w-[110px]',
+        version === 'Filter' ? 'w-full' : 'w-[110px] desktop:w-[142px]',
       )}
     >
       {options.map((option) => (
@@ -36,7 +36,9 @@ export default function Dropdown({
           onClick={() => handleSelect(option)}
           className={cn(
             'm-1 block rounded-xl px-4 py-2 text-left hover:bg-secondary-200',
-            version === 'Input' ? 'w-[464px]' : 'w-[102px]',
+            version === 'Filter'
+              ? 'w-[calc(100%-8px)]'
+              : 'h-10 w-[calc(100%-8px)] desktop:h-11',
             selectedOption === option ? 'bg-orange-100' : '',
           )}
         >

--- a/src/components/common/dropdown.tsx
+++ b/src/components/common/dropdown.tsx
@@ -1,5 +1,7 @@
 import { type ComponentPropsWithoutRef } from 'react';
 
+import { cn } from '~/src/utils/class-name';
+
 interface dropdownProps
   extends Omit<ComponentPropsWithoutRef<'button'>, 'onClick' | 'onSelect'> {
   onClick?: (option: string) => void;
@@ -22,18 +24,21 @@ export default function Dropdown({
 
   return (
     <div
-      className={`absolute mt-2 rounded-xl bg-white shadow-lg ${
-        version === 'Input' ? 'w-[472px]' : 'w-[110px]'
-      }`}
+      className={cn(
+        'absolute mt-2 rounded-xl bg-white shadow-lg',
+        version === 'Input' ? 'w-[472px]' : 'w-[110px]',
+      )}
     >
       {options.map((option) => (
         <button
           {...rest}
           key={option}
           onClick={() => handleSelect(option)}
-          className={`m-1 block rounded-xl px-4 py-2 text-left hover:bg-secondary-200 ${
-            version === 'Input' ? 'w-[464px]' : 'w-[102px]'
-          } ${selectedOption === option ? 'bg-orange-100' : ''}`}
+          className={cn(
+            'm-1 block rounded-xl px-4 py-2 text-left hover:bg-secondary-200',
+            version === 'Input' ? 'w-[464px]' : 'w-[102px]',
+            selectedOption === option ? 'bg-orange-100' : '',
+          )}
         >
           {option}
         </button>

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -18,7 +18,9 @@ export default function Filter({ version, options, ...rest }: filterProps) {
   );
   const [isOpen, setIsOpen] = useState(false);
 
-  const toggleDropdown = () => setIsOpen(!isOpen);
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
   const selectOption = (option: string) => {
     setSelected(option);
     setIsOpen(false);
@@ -31,13 +33,18 @@ export default function Filter({ version, options, ...rest }: filterProps) {
         onClick={toggleDropdown}
         className={cn(
           'flex h-9 rounded-xl border-[2px] border-secondary-100 bg-white px-3 py-[6px] text-secondary-800',
-          'sm:h-10 sm:py-2',
+          'mobile:h-10 mobile:py-2',
           version === 'Right' &&
-            (isOpen
-              ? 'justify-between border-none bg-secondary-900 text-secondary-50'
-              : 'justify-between hover:bg-secondary-50'),
+            cn(
+              isOpen
+                ? 'justify-between border-none bg-secondary-900 text-secondary-50'
+                : 'justify-between hover:bg-secondary-50',
+            ),
           version === 'Left' &&
-            'h-9 w-9 px-[6px] py-[6px] hover:bg-secondary-50 sm:w-[120px] sm:gap-[10px] sm:px-3 sm:py-2',
+            cn(
+              'h-9 w-9 px-[6px] py-[6px] hover:bg-secondary-50',
+              'mobile:w-[120px] mobile:gap-[10px] mobile:px-3 mobile:py-2',
+            ),
           version !== 'Left' && 'w-[110px]',
         )}
       >
@@ -46,18 +53,21 @@ export default function Filter({ version, options, ...rest }: filterProps) {
           alt="sortIcon"
           width={24}
           height={24}
-          className={`${version === 'Left' ? 'text-left' : 'hidden'}`}
+          className={cn(version === 'Left' ? 'text-left' : 'hidden')}
         />
 
         <div
-          className={`flex items-center text-sm ${version === 'Left' ? 'hidden sm:block' : ''}`}
+          className={cn(
+            'flex items-center text-sm',
+            version === 'Left' ? 'hidden mobile:block' : '',
+          )}
         >
           {selected}
         </div>
         <Image
           src={isOpen ? DownCaretInverse : DownCaret}
           alt="Caret Icon"
-          className={version === 'Right' ? 'text-left' : 'hidden'}
+          className={cn(version === 'Right' ? 'text-left' : 'hidden')}
           width={24}
           height={24}
         />

--- a/src/components/common/filter.tsx
+++ b/src/components/common/filter.tsx
@@ -27,7 +27,7 @@ export default function Filter({ version, options, ...rest }: filterProps) {
   };
 
   return (
-    <div className="relative">
+    <div className="relative whitespace-nowrap">
       <button
         {...rest}
         onClick={toggleDropdown}
@@ -43,9 +43,10 @@ export default function Filter({ version, options, ...rest }: filterProps) {
           version === 'Left' &&
             cn(
               'h-9 w-9 px-[6px] py-[6px] hover:bg-secondary-50',
-              'mobile:w-[120px] mobile:gap-[10px] mobile:px-3 mobile:py-2',
+              'w-auto',
+              'mobile:min-w-[120px] mobile:gap-[10px] mobile:px-3 mobile:py-2',
             ),
-          version !== 'Left' && 'w-[110px]',
+          version !== 'Left' && 'min-w-[110px]',
         )}
       >
         <Image


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
레이아웃 적용(mobile,tablet,desktop)

## 🎉 변경 사항

-드롭다운의 version을 GNB에서 사용하는 드롭다운을 Login, 그 이외에는 Filter로 설정했습니다.

- Filter일 때는 드롭다운과 필터의 width를 통일하였고 필터의 width는 최소만 잡고 선택된 옵션의 길이에 따라 조절이 되게 하였습니다.
- Login일 때는 피그마에 나와있는 대로 고정해 두었습니다 

## 🙏 여기는 꼭 봐주세요!
![ani5](https://github.com/user-attachments/assets/df68ac42-1967-4d95-94cd-83495b0697cf)
<version==='Filter'>
![ani6](https://github.com/user-attachments/assets/f19bff6f-1f7b-4e77-943e-903f14aab0de)
<version==='Login'>
