### PR TITLE
feat: authpage gnb 구현

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,3 +1,39 @@
+import Link from 'next/link';
+
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardTitle,
+} from '~/src/components/authpage/auth-formcard';
+import AuthPageBg from '~/src/components/authpage/authpage-bg';
+import LoginForm from '~/src/components/authpage/login-form';
+import MainContainer from '~/src/components/layout/main-container';
+
 export default function LoginPage() {
-  return <div>LoginPage</div>;
+  return (
+    <MainContainer className="flex items-center justify-center bg-transparent desktop:px-0">
+      <div className="flex flex-col items-center justify-between gap-0 px-0 tablet:flex-row tablet:gap-24 md:flex-row">
+        <div className="w-full">
+          <AuthPageBg />
+        </div>
+        <div className="w-full">
+          <Card>
+            <CardTitle>로그인</CardTitle>
+            <CardContent>
+              <LoginForm />
+            </CardContent>
+            <CardFooter>
+              <p>
+                같이 달램이 처음이신가요 ?{' '}
+                <Link className="text-primary-600 underline" href="/signup">
+                  회원가입
+                </Link>
+              </p>
+            </CardFooter>
+          </Card>
+        </div>
+      </div>
+    </MainContainer>
+  );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,3 +1,39 @@
+import Link from 'next/link';
+
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardTitle,
+} from '~/src/components/authpage/auth-formcard';
+import AuthPageBg from '~/src/components/authpage/authpage-bg';
+import SignupForm from '~/src/components/authpage/signup-form';
+import MainContainer from '~/src/components/layout/main-container';
+
 export default function SignupPage() {
-  return <div>SignupPage</div>;
+  return (
+    <MainContainer className="flex items-center justify-center bg-transparent desktop:px-0">
+      <div className="flex flex-col items-center justify-between gap-0 px-0 tablet:flex-row tablet:gap-24 md:flex-row">
+        <div className="w-full md:w-1/2">
+          <AuthPageBg />
+        </div>
+        <div className="w-full md:w-1/2">
+          <Card>
+            <CardTitle>회원가입</CardTitle>
+            <CardContent>
+              <SignupForm />
+            </CardContent>
+            <CardFooter>
+              <p>
+                이미 회원이신가요 ?{' '}
+                <Link className="text-primary-600 underline" href="/login">
+                  로그인
+                </Link>
+              </p>
+            </CardFooter>
+          </Card>
+        </div>
+      </div>
+    </MainContainer>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "rest-mate-client",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-dialog": "^1.1.2",
+        "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-slot": "^1.1.0",
         "@sentry/nextjs": "^8.40.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -16,9 +19,11 @@
         "react": "^18",
         "react-day-picker": "^9.4.0",
         "react-dom": "^18",
+        "react-hook-form": "^7.53.2",
         "tailwind-merge": "^2.5.5",
         "tailwind-scrollbar": "^3.1.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.6.0",
@@ -2649,6 +2654,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.1.tgz",
+      "integrity": "sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -4740,6 +4754,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+      "integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -15413,6 +15450,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.53.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
+      "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -18139,6 +18192,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "cy:run": "cypress run"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
     "@sentry/nextjs": "^8.40.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -26,9 +29,11 @@
     "react": "^18",
     "react-day-picker": "^9.4.0",
     "react-dom": "^18",
+    "react-hook-form": "^7.53.2",
     "tailwind-merge": "^2.5.5",
     "tailwind-scrollbar": "^3.1.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",

--- a/src/components/authpage/auth-formcard.tsx
+++ b/src/components/authpage/auth-formcard.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import { cn } from '~/src/utils/class-name';
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'flex w-full flex-col items-center justify-center gap-[10px] rounded-2xl bg-white px-[54px] py-[32px]',
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('p-2 text-2xl font-semibold text-secondary-800', className)}
+    {...props}
+  />
+));
+CardTitle.displayName = 'CardTitle';
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('w-full', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center whitespace-nowrap p-2', className)}
+    {...props}
+  />
+));
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardContent, CardFooter, CardTitle };

--- a/src/components/authpage/authpage-bg.tsx
+++ b/src/components/authpage/authpage-bg.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image';
+
+import bgLoginImage from '~/src/assets/images/bg-login.png';
+
+export default function AuthPageBg() {
+  return (
+    <>
+      <div className="flex w-full flex-col items-center gap-[8px] px-24 text-center text-secondary-800 tablet:px-12">
+        <h1 className="white-space-nowrap text-2xl font-semibold">
+          Welcome to 같이 달램!
+        </h1>
+        <p className="white-space-nowrap font-medium">
+          바쁜 일상 속 잠깐의 휴식, <br />
+          이제는 같이 달램과 함께 해보세요
+        </p>
+        <div>
+          <Image
+            src={bgLoginImage}
+            alt="login background"
+            objectFit="cover"
+          ></Image>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/authpage/form.tsx
+++ b/src/components/authpage/form.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Controller,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  useFormContext,
+} from 'react-hook-form';
+import type * as LabelPrimitive from '@radix-ui/react-label';
+
+import { Label } from '~/src/components/authpage/label';
+import { cn } from '~/src/utils/class-name';
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>');
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+);
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn('space-y-2', className)} {...props} />
+    </FormItemContext.Provider>
+  );
+});
+FormItem.displayName = 'FormItem';
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && 'text-destructive', className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = 'FormLabel';
+
+export { Form, FormField, FormItem, FormLabel, useFormField };

--- a/src/components/authpage/label.tsx
+++ b/src/components/authpage/label.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '~/src/utils/class-name';
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/src/components/authpage/login-form.tsx
+++ b/src/components/authpage/login-form.tsx
@@ -1,0 +1,77 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '~/src/components/authpage/form';
+import Button from '~/src/components/common/button';
+import Input from '~/src/components/common/input';
+
+const formSchema = z.object({
+  email: z.string().nonempty({ message: '이메일을 입력해주세요' }),
+  password: z.string().nonempty({ message: '비밀번호를 입력해주세요' }),
+});
+
+export default function LoginForm() {
+  const rotuer = useRouter();
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    mode: 'onSubmit',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    console.log(values);
+    rotuer.push('/');
+    alert('로그인 성공' + JSON.stringify(values));
+  }
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="flex w-full flex-col gap-[24px]"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel htmlFor="email">아이디</FormLabel>
+              <Input
+                error={form.formState.errors.email?.message}
+                type="email"
+                placeholder="아이디를 입력해주세요"
+                {...field}
+              />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel htmlFor="password">비밀번호</FormLabel>
+              <Input
+                error={form.formState.errors.password?.message}
+                type="password"
+                placeholder="비밀번호를 입력해주세요"
+                {...field}
+              />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">로그인</Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/authpage/signup-form.tsx
+++ b/src/components/authpage/signup-form.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '~/src/components/authpage/form';
+import Button from '~/src/components/common/button';
+import Input from '~/src/components/common/input';
+
+const passwordRegex =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$&*?!%])[A-Za-z\d!@$%&*?]{8,15}$/;
+
+const formSchema = z
+  .object({
+    username: z
+      .string()
+      .min(2, {
+        message: '이름은 2글자 이상이어야 합니다.',
+      })
+      .nonempty({ message: '이름을 입력해주세요' }),
+    email: z
+      .string()
+      .email({ message: '이메일 형식이 아닙니다.' })
+      .nonempty({ message: '이메일을 입력해주세요' }),
+    company: z
+      .string()
+      .min(2, { message: '회사명을 정확히 입력해주세요' })
+      .nonempty({ message: '회사명을 입력해주세요' }),
+    password: z
+      .string()
+      .min(8, { message: '비밀번호는 8자리 이상이어야 합니다.' })
+      .regex(passwordRegex, {
+        message: '영문, 숫자, 특수문자(~!@#$%^&*)를 모두 조합해 주세요.',
+      })
+      .nonempty({ message: '비밀번호를 입력해주세요' }),
+    confirmPassword: z
+      .string()
+      .nonempty({ message: '비밀번호를 다시 입력해주세요' }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ['confirmPassword'],
+    message: '비밀번호가 일치하지 않습니다.',
+  });
+
+export default function SignupForm() {
+  const router = useRouter();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    mode: 'onSubmit',
+    // 기능 요구 사항 검사 시점 버튼 클릭 후라서 'onSubmit' 으로 설정
+    defaultValues: {
+      username: '',
+      email: '',
+      company: '',
+      password: '',
+      confirmPassword: '',
+    },
+  });
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    console.log(values);
+    alert('회원가입이 완료되었습니다.' + JSON.stringify(values));
+    router.push('/login');
+  }
+
+  console.log(form.formState.errors);
+  return (
+    <>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex w-full flex-col gap-[24px]"
+        >
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="username">이름</FormLabel>
+                <Input
+                  error={form.formState.errors.username?.message}
+                  type="text"
+                  placeholder="이름을 입력해주세요"
+                  {...field}
+                />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="email">이메일</FormLabel>
+                <Input
+                  error={form.formState.errors.email?.message}
+                  type="email"
+                  placeholder="이메일을 입력해주세요"
+                  {...field}
+                />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="company"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="company">회사</FormLabel>
+                <Input
+                  error={form.formState.errors.company?.message}
+                  type="text"
+                  placeholder="회사를 입력해주세요"
+                  {...field}
+                />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="password">비밀번호</FormLabel>
+                <Input
+                  error={form.formState.errors.password?.message}
+                  type="password"
+                  placeholder="비밀번호를 입력해주세요"
+                  {...field}
+                />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="confirmPassword">비밀번호 확인</FormLabel>
+                <Input
+                  error={form.formState.errors.confirmPassword?.message}
+                  type="password"
+                  placeholder="비밀번호를 입력해주세요"
+                  {...field}
+                />
+              </FormItem>
+            )}
+          />
+          <Button type="submit">회원가입</Button>
+        </form>
+      </Form>
+    </>
+  );
+}

--- a/src/components/common/active-link.tsx
+++ b/src/components/common/active-link.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface ActiveLinkProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+export default function ActiveLink({ href, children }: ActiveLinkProps) {
+  const pathname = usePathname();
+
+  const linkClassName = pathname === href ? 'link text-secondary-900' : 'link';
+
+  return (
+    <Link href={href} className={linkClassName}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/common/gnb.tsx
+++ b/src/components/common/gnb.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import ActiveLink from '~/src/components/common/active-link';
+import Logo from '~/src/components/common/logo';
+
+export default function Gnb() {
+  return (
+    <nav className="flex gap-4">
+      <Logo />
+
+      <ActiveLink href="/gatherings">모임 찾기</ActiveLink>
+      <ActiveLink href="/wishlist">찜한 모임</ActiveLink>
+      <ActiveLink href="/all-reviews">모든 리뷰</ActiveLink>
+    </nav>
+  );
+}

--- a/src/components/common/logo.tsx
+++ b/src/components/common/logo.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function Logo() {
+  return (
+    <Link href="/" className="font-bold">
+      같이 달램
+    </Link>
+  );
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,15 +1,21 @@
-import { cn } from '~/src/utils/class-name';
+import Link from 'next/link';
 
+import Gnb from '~/src/components/common/gnb';
+import { cn } from '~/src/utils/class-name';
 export default function Header() {
   return (
-    <header className="fixed inset-x-0 top-0 z-10 h-header border-b-2 border-secondary-900 bg-primary-600 font-semibold text-primary-50">
+    <header className="fixed inset-x-0 top-0 z-10 h-header border-b-2 border-secondary-900 bg-primary-600 text-primary-50">
       <section
         className={cn(
           'mx-auto flex h-full max-w-screen-desktop items-center justify-between',
           'px-4 tablet:px-6 desktop:px-0',
         )}
       >
-        {/* 여기에 코드 작성하시면 됩니다~ */}
+        <Gnb />
+        <div>
+          {/* <Link href="/mypage">마이페이지</Link> */}
+          <Link href="/login">로그인</Link>
+        </div>
       </section>
     </header>
   );


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

로그인 회원가입 페이지 gnb 구현 

## 🎉 변경 사항
## 설치한 것 

```
npm install @radix-ui/react-label @radix-ui/react-slot react-hook-form @hookform/resolvers zod

```

auth page 로그인 / 회원가입 
에러메세지 / 폼 / 레이아웃 디자인 작업 

zod로 유효성 검사 
기능 요구사항에 폼 제출 시에 에러메세지 보이게 하라는 말이 있어서 mode는 onSubmit으로 했습니다 
shadcn ui 참고하여 label, card, form 컴포넌트 분리 완
📌 form 컴포넌트는 추가적으로 수정 필요할 시에 꼭 리뷰 남겨주세요 

gnb 

공식문서에서 link active 관련 자료 보고 구현 active는 공통컴포넌트로 사용할 수 있게 함 
https://nextjs.org/docs/app/api-reference/components/link

logo 따로 분리 

로그인 여부에 따라 프로필 사진으로 바뀌는 건 추후에 개발 예정 


## 🙏 여기는 꼭 봐주세요!
