### PR TITLE
feat: input 에러 수정

### DIFF
--- a/src/components/common/input.tsx
+++ b/src/components/common/input.tsx
@@ -1,48 +1,51 @@
 'use client';
 
-import { type ComponentPropsWithoutRef, useState } from 'react';
+import { forwardRef, useState } from 'react';
 
 import Visibility from '~/src/assets/icons/visibility';
 import { cn } from '~/src/utils/class-name';
 
-interface InputProps extends ComponentPropsWithoutRef<'input'> {
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
 }
-export default function Input({
-  error,
-  type,
-  className,
-  ...props
-}: InputProps) {
-  const [showPassword, setShowPassword] = useState(false);
 
-  const togglePassword = () => {
-    setShowPassword((prevState) => !prevState);
-  };
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ error, type, className, ...props }: InputProps, ref) => {
+    const [showPassword, setShowPassword] = useState(false);
 
-  return (
-    <>
-      <div className="relative">
-        <input
-          {...props}
-          className={cn(
-            'w-full rounded-xl bg-gray-50 px-[16px] py-[10px] focus:outline-orange-600',
-            error && 'border-2 border-red-600',
-            className,
+    const togglePassword = () => {
+      setShowPassword((prevState) => !prevState);
+    };
+
+    return (
+      <>
+        <div className="relative">
+          <input
+            {...props}
+            ref={ref}
+            className={cn(
+              'w-full rounded-xl bg-gray-50 px-[16px] py-[10px] focus:outline-orange-600',
+              error && 'border-2 border-red-600',
+              className,
+            )}
+            type={showPassword && type === 'password' ? 'text' : type}
+          />
+          {type === 'password' && (
+            <button
+              type="button"
+              onClick={togglePassword}
+              className="absolute right-2 top-1/2 -translate-y-1/2 transform"
+            >
+              <Visibility isVisible={showPassword} />
+            </button>
           )}
-          type={showPassword && type === 'password' ? 'text' : type}
-        />
-        {type === 'password' && (
-          <button
-            type="button"
-            onClick={togglePassword}
-            className="absolute right-2 top-1/2 -translate-y-1/2 transform"
-          >
-            <Visibility isVisible={showPassword} />
-          </button>
-        )}
-      </div>
-      {error && <span className={cn('text-sm text-red-600')}>{error}</span>}
-    </>
-  );
-}
+        </div>
+        {error && <span className={cn('text-sm text-red-600')}>{error}</span>}
+      </>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+
+export default Input;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

파일이 안 열리거나 동작에 지장 가는 에러는 발견하지 못했지만 
회원가입 로그인 데이터 값 전달 콘솔에서 확인하던 중 에러가 있다는 걸 발견 


hook.js:608 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()? 


콘솔에 이런 에러가 뜨고 있었고, 

챗 지피티에 검색했을 때 

> 이 경고 메시지는 함수형 컴포넌트가 ref를 받으려고 시도했을 때 발생합니다. ref를 함수형 컴포넌트에 직접 전달하려고 하면 이 오류가 발생할 수 있습니다. ref를 사용하려면 React.forwardRef()를 사용하여 컴포넌트를 감싸야 합니다.

이 문제를 해결하려면 Input 컴포넌트를 forwardRef로 감싸서 ref를 전달할 수 있도록 해야 합니다. 

라고 떠서 수정했습니다 

## 📚 안 까먹기 위해 공부하면서 정리 

react-hook-form과 같은 라이브러리에서는 Controller 컴포넌트를 통해 폼을 다루는데, 
Controller는 작성한 값을 폼 상태와 연결하거나 외부 UI 컴포넌트에 ref 전달하기 땜에 수정이 필요했다. 

> forwardRef의 역할
forwardRef는 부모 컴포넌트가 자식 컴포넌트의 DOM 요소나 특정 컴포넌트 인스턴스에 접근할 수 있도록 해준다. 

기본적으로 ref는 DOM 요소나 클래스형 컴포넌트 인스턴스에만 접근할 수 있기 때문에, 
함수형 컴포넌트에서는 ref를 전달할 수 없었다는 점을 다시 한 번 더 알게 된 계기였습니다 

