### PR TITLE
배포 관련 CI 추가

### DIFF
--- a/.github/workflows/synchronize-forked-repo.yaml
+++ b/.github/workflows/synchronize-forked-repo.yaml
@@ -1,0 +1,30 @@
+name: Synchronize forked repo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    name: Sync forked repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FORKED_REPO_TOKEN}}
+          fetch-depth: 0
+          ref: main
+
+      - name: Add remote-url
+        run: |
+          git remote add forked-repo https://devyouth94:${{ secrets.FORKED_REPO_TOKEN}}@github.com/devyouth94/rest-mate-client
+          git config user.name "devyouth94"
+          git config user.email "devyouth94@gmail.com"
+
+      - name: Push changes to forked-repo
+        run: git push -f forked-repo main
+
+      - name: Clean up
+        run: git remote remove forked-repo

--- a/.github/workflows/synchronize-forked-repo.yaml
+++ b/.github/workflows/synchronize-forked-repo.yaml
@@ -1,11 +1,13 @@
 name: Synchronize forked repo
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: [main]
 
 jobs:
   sync:
+    if: github.event.pull_request.merged == true
     name: Sync forked repo
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
자동화를 위한 CI 추가합니다~

1. organization에 들어가있는 repo는 vercel에 배포하려면 유료로 바꿔야합니다.
2. 그래서 repo를 개인 깃허브에 포크해오고 그 포크한 레포를 배포해야합니다.
3. 팀 main브랜치를 개인 main 브랜치에 sync를 완료해야 배포가 자동으로 진행됩니다.
4. 귀찮으니까 팀 main 브랜치에 pull_request되고 merge 됐을때 개인 main 브랜치에 자동으로 push 합니다.
5. 배포 자동으로 됨~~