### PR TITLE
토스트 추가 및 공통 세팅 css 값 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { pretendard } from '~/src/fonts/fonts';
 import JotaiProvider from '~/src/providers/jotai-provider';
 import MSWProvider from '~/src/providers/msw-provider';
 import TanstackQueryProvider from '~/src/providers/tanstack-query-provider';
+import ToastProvider from '~/src/providers/toast-provider';
 import { cn } from '~/src/utils/class-name';
 
 import '~/src/styles/globals.css';
@@ -29,6 +30,7 @@ export default function RootLayout({ children }: Readonly<Props>) {
         <MSWProvider>
           <JotaiProvider>
             <TanstackQueryProvider>
+              <ToastProvider />
               <Header />
               {children}
             </TanstackQueryProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,10 @@ export default function RootLayout({ children }: Readonly<Props>) {
   return (
     <html lang="ko">
       <body
-        className={cn(pretendard.variable, 'bg-secondary-100 font-pretendard')}
+        className={cn(
+          pretendard.variable,
+          'bg-secondary-100 font-pretendard font-medium text-secondary-800',
+        )}
       >
         <MSWProvider>
           <JotaiProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-day-picker": "^9.4.0",
         "react-dom": "^18",
         "react-hook-form": "^7.53.2",
+        "sonner": "^1.7.1",
         "tailwind-merge": "^2.5.5",
         "tailwind-scrollbar": "^3.1.0",
         "tailwindcss-animate": "^1.0.7",
@@ -17186,6 +17187,16 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.1.tgz",
+      "integrity": "sha512-b6LHBfH32SoVasRFECrdY8p8s7hXPDn3OHUFbZZbiB1ctLS9Gdh6rpX2dVrpQA0kiL5jcRzDDldwwLkSKk3+QQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-day-picker": "^9.4.0",
     "react-dom": "^18",
     "react-hook-form": "^7.53.2",
+    "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwind-scrollbar": "^3.1.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/common/modal.tsx
+++ b/src/components/common/modal.tsx
@@ -41,7 +41,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
-        'grid w-full max-w-[520px] gap-6 rounded-xl bg-white p-6 shadow-lg duration-200',
+        'grid w-[calc(100dvw-32px)] gap-6 rounded-xl bg-white p-6 shadow-lg duration-200 tablet:w-full tablet:max-w-[520px]',
         'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]',
         className,

--- a/src/components/gatherings/create-gathering-modal/index.tsx
+++ b/src/components/gatherings/create-gathering-modal/index.tsx
@@ -75,7 +75,7 @@ export default function CreateGatheringModal() {
         aria-describedby="모임 만들기 폼"
         className={cn(
           'flex h-dvh flex-col tablet:h-[calc(100dvh-48px)] desktop:h-dvh',
-          'max-tablet:max-w-full max-tablet:rounded-none max-tablet:px-4 max-tablet:pb-3',
+          'w-full max-tablet:rounded-none max-tablet:px-4 max-tablet:pb-3',
         )}
       >
         <DialogHeader>

--- a/src/providers/toast-provider.tsx
+++ b/src/providers/toast-provider.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { Toaster } from 'sonner';
+
+export default function ToastProvider() {
+  return <Toaster richColors className="z-[100]" />;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import axios, { isAxiosError } from 'axios';
 import Cookie from 'js-cookie';
+import { toast } from 'sonner';
 
 export const API_URL = `https://fe-adv-project-together-dallaem.vercel.app/${process.env.NEXT_PUBLIC_TEAM_ID}`;
 
@@ -29,6 +30,9 @@ instance.interceptors.response.use(
   },
   (error) => {
     if (!isAxiosError(error) || !error.response) return Promise.reject(error);
+
+    // 모든 토스트 에러 처리는 여기서 분기처리로 하면 될것 같습니다!!
+    toast.error(error.response.data?.message || '에러가 발생했습니다');
 
     return Promise.reject(error.response);
   },


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
1. 토스트 추가
2. css 수정

## 🎉 변경 사항
### 토스트 UI 추가했습니다
![image](https://github.com/user-attachments/assets/e7c5e27f-b9f3-4b4f-8f23-548282b7ee3d)
- 전역으로 관리할 수 있도록 인터셉터 부분에 toast 로직 추가했습니다.
- 우선 서버에서 보내주는 메시지를 렌더링하도록 했고, 만약 메시지가 없을때를 대비하여 placeholder 설정했습니다.
- 만약 status혹은 code 값을 통해 메시지를 커스텀하고 싶다면 custom-error.ts 유틸 함수 만들어서 인터셉터에서 호출하면 될것 같습니다

### 폰트 기본 설정 추가했습니다
- 이슈 의견 반영하여 text-secondary-800, font-medium 루트 레이아웃에 추가했습니다.
- 컴포넌트 내에 적용했던 기본값들 있으면 추후 수정작업에서 지워주시면 될것 같습니다~!

### 모달 모바일일때 기본 좌우 마진 추가했습니다. 7161a876b00a6f43149a341d8b2f345f80b783b8
![image](https://github.com/user-attachments/assets/c0f234c1-b5f6-4dd0-955b-9fd031812e0b)
- 기본값이었던 `tablet:w-full tablet:max-w-[520px]`를 tablet으로 미디어 쿼리 처리하고
- `w-[calc(100dvw-32px)]`값을 추가했습니다.


## 🙏 여기는 꼭 봐주세요!
