### PR TITLE
모든 리뷰 페이지 마무리 작업

### DIFF
--- a/app/all-reviews/page.tsx
+++ b/app/all-reviews/page.tsx
@@ -1,6 +1,7 @@
 import PageTitleWithImage from '~/src/components/common/page-title-with-image';
 import MainContainer from '~/src/components/layout/main-container';
 import ReviewContainer from '~/src/components/reviews/review-container';
+import ReviewFilter from '~/src/components/reviews/review-filter';
 import ReviewGatheringTab from '~/src/components/reviews/review-gathering-tab';
 import ReviewList from '~/src/components/reviews/review-list';
 import ReviewScore from '~/src/components/reviews/review-score';
@@ -30,6 +31,8 @@ export default async function AllReviewsPage() {
       <ReviewScore />
 
       <ReviewContainer>
+        <ReviewFilter />
+
         <Hydration state={state}>
           <ReviewList />
         </Hydration>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 
@@ -5,6 +6,7 @@ import Header from '~/src/components/layout/header';
 import { pretendard } from '~/src/fonts/fonts';
 import JotaiProvider from '~/src/providers/jotai-provider';
 import MSWProvider from '~/src/providers/msw-provider';
+import NavigationProvider from '~/src/providers/navigation-provider';
 import TanstackQueryProvider from '~/src/providers/tanstack-query-provider';
 import { cn } from '~/src/utils/class-name';
 
@@ -27,13 +29,18 @@ export default function RootLayout({ children }: Readonly<Props>) {
         className={cn(pretendard.variable, 'bg-secondary-100 font-pretendard')}
       >
         <MSWProvider>
-          <JotaiProvider>
-            <TanstackQueryProvider>
+          <TanstackQueryProvider>
+            <JotaiProvider>
+              <Suspense fallback={null}>
+                <NavigationProvider />
+              </Suspense>
+
               <Header />
               {children}
-            </TanstackQueryProvider>
-          </JotaiProvider>
+            </JotaiProvider>
+          </TanstackQueryProvider>
         </MSWProvider>
+
         <SpeedInsights />
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-day-picker": "^9.4.0",
         "react-dom": "^18",
         "react-hook-form": "^7.53.2",
+        "react-intersection-observer": "^9.13.1",
         "tailwind-merge": "^2.5.5",
         "tailwind-scrollbar": "^3.1.0",
         "tailwindcss-animate": "^1.0.7",
@@ -16411,6 +16412,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.1.tgz",
+      "integrity": "sha512-tSzDaTy0qwNPLJHg8XZhlyHTgGW6drFKTtvjdL+p6um12rcnp8Z5XstE+QNBJ7c64n5o0Lj4ilUleA41bmDoMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-day-picker": "^9.4.0",
     "react-dom": "^18",
     "react-hook-form": "^7.53.2",
+    "react-intersection-observer": "^9.13.1",
     "tailwind-merge": "^2.5.5",
     "tailwind-scrollbar": "^3.1.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/common/right-filter.tsx
+++ b/src/components/common/right-filter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useRef, useState } from 'react';
 import Image from 'next/image';
 
@@ -14,6 +16,7 @@ interface FilterProps extends React.ComponentPropsWithoutRef<'button'> {
   calendar?: boolean;
   onOptionSelect?: (option: string) => void;
   onDateSelect?: (date: Date) => void;
+  onDateReset?: () => void;
 }
 
 function Yymmdd(date: Date) {
@@ -31,6 +34,7 @@ export default function RightFilter({
   calendar = false,
   onOptionSelect,
   onDateSelect,
+  onDateReset,
   ...rest
 }: FilterProps) {
   const [selected, setSelected] = useState(placeholder);
@@ -60,7 +64,8 @@ export default function RightFilter({
   const handleReset = useCallback(() => {
     setSelected(placeholder);
     setSelectedDate(undefined);
-  }, [placeholder]);
+    onDateReset?.();
+  }, [placeholder, onDateReset]);
 
   return (
     <div className="relative whitespace-nowrap">

--- a/src/components/reviews/review-filter.tsx
+++ b/src/components/reviews/review-filter.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import LeftFilter from '~/src/components/common/left-filter';
+import RightFilter from '~/src/components/common/right-filter';
+import useReviewFilterAtom from '~/src/hooks/reviews/use-review-filter-atom';
+import { type ReviewSortBy } from '~/src/services/reviews/types';
+import { type GatheringLocation } from '~/src/services/types';
+import { getDateForFormData } from '~/src/utils/date';
+
+const SORT_OPTIONS: Record<string, ReviewSortBy> = {
+  최신순: 'createdAt',
+  '리뷰 높은 순': 'score',
+  '참여 인원 순': 'participantCount',
+};
+
+export default function ReviewFilter() {
+  const { onChangeFilter } = useReviewFilterAtom();
+
+  const handleLocationSelect = (value: string) => {
+    const location =
+      value === '전체' ? undefined : (value as GatheringLocation);
+    onChangeFilter({ location });
+  };
+
+  const handleDateSelect = (date: Date) => {
+    onChangeFilter({ date: getDateForFormData(date) });
+  };
+
+  const handleDateReset = () => {
+    onChangeFilter({ date: undefined });
+  };
+
+  const handleSortBySelect = (value: string) => {
+    const sortBy = SORT_OPTIONS[value];
+    onChangeFilter({ sortBy });
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex gap-2">
+        <RightFilter
+          options={['전체', '건대입구', '을지로3가', '신림', '홍대입구']}
+          onOptionSelect={handleLocationSelect}
+          placeholder="지역 선택"
+        />
+
+        <RightFilter
+          calendar
+          options={[]}
+          onDateSelect={handleDateSelect}
+          onDateReset={handleDateReset}
+          placeholder="날짜 선택"
+        />
+      </div>
+
+      <LeftFilter
+        options={Object.keys(SORT_OPTIONS)}
+        onOptionSelect={handleSortBySelect}
+      />
+    </div>
+  );
+}

--- a/src/components/reviews/review-list.tsx
+++ b/src/components/reviews/review-list.tsx
@@ -1,23 +1,41 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
 import ReviewCardItem from '~/src/components/reviews/review-card-item';
 import useGetReviewInfiniteList from '~/src/services/reviews/use-get-review-infinite-list';
 
 export default function ReviewList() {
-  const { data, isFetching } = useGetReviewInfiniteList();
+  const { ref, inView } = useInView();
+
+  const { data, hasNextPage, isFetching, fetchNextPage } =
+    useGetReviewInfiniteList();
+
+  useEffect(() => {
+    if (!inView) return;
+
+    if (!isFetching && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, inView, isFetching]);
 
   return (
     <div className="flex grow flex-col">
       {/* 데이터 있을때 */}
-      {data?.map((data) => (
-        <ReviewCardItem
-          key={data.id}
-          {...data}
-          hasImage
-          hasTypeDescription
-          hasNameTag
-        />
-      ))}
+      <div>
+        {data?.map((data) => (
+          <ReviewCardItem
+            key={data.id}
+            {...data}
+            hasImage
+            hasTypeDescription
+            hasNameTag
+          />
+        ))}
+
+        {!isFetching && hasNextPage && <div ref={ref} className="h-10" />}
+      </div>
 
       {/* 첫 페칭이 끝나고 데이터 없을때 */}
       {!isFetching && data?.length === 0 && (

--- a/src/hooks/reviews/use-review-filter-atom.ts
+++ b/src/hooks/reviews/use-review-filter-atom.ts
@@ -1,4 +1,6 @@
+import { useCallback } from 'react';
 import { useAtom } from 'jotai';
+import { useResetAtom } from 'jotai/utils';
 
 import {
   type ReviewFilter,
@@ -7,10 +9,14 @@ import {
 
 export default function useReviewFilterAtom() {
   const [filter, setFilter] = useAtom(reviewFilterAtom);
+  const onResetFilter = useResetAtom(reviewFilterAtom);
 
-  const onChangeFilter = (filter: ReviewFilter) => {
-    setFilter((prev) => ({ ...prev, ...filter }));
-  };
+  const onChangeFilter = useCallback(
+    (filter: ReviewFilter) => {
+      setFilter((prev) => ({ ...prev, ...filter }));
+    },
+    [setFilter],
+  );
 
-  return { filter, onChangeFilter };
+  return { filter, onChangeFilter, onResetFilter };
 }

--- a/src/mocks/handler/reviews.ts
+++ b/src/mocks/handler/reviews.ts
@@ -3,8 +3,13 @@ import { http, HttpResponse } from 'msw';
 import { baseUrl, getQueryParams } from '~/src/mocks/utils';
 
 export const reviewsHandlers = [
-  http.get(baseUrl('/reviews'), () => {
-    return HttpResponse.json([
+  http.get(baseUrl('/reviews'), ({ request }) => {
+    const { limit, offset } = getQueryParams(request.url, [
+      'limit',
+      'offset',
+    ] as const);
+
+    const baseReviews = [
       {
         teamId: 1,
         id: 1,
@@ -18,13 +23,13 @@ export const reviewsHandlers = [
           name: '달램핏 오피스 스트레칭',
           dateTime: '2024-03-19T15:00:00Z',
           location: '건대입구',
-          image: '/IMG_1190.jpg',
+          image: '/IMG_1053.jpg',
         },
         User: {
           teamId: 1,
           id: 201,
           name: '김철수',
-          image: '/IMG_1053.jpg',
+          image: '/IMG_1190.jpg',
         },
       },
       {
@@ -49,7 +54,46 @@ export const reviewsHandlers = [
           image: '/IMG_1053.jpg',
         },
       },
-    ]);
+    ];
+
+    const reviews = Array.from({ length: 13 }, (_, index) => {
+      const multiplier = index * 2;
+      return [
+        {
+          ...baseReviews[0],
+          id: multiplier + 1,
+          User: {
+            ...baseReviews[0].User,
+            id: baseReviews[0].User.id + multiplier,
+          },
+          Gathering: {
+            ...baseReviews[0].Gathering,
+            id: baseReviews[0].Gathering.id + multiplier,
+          },
+        },
+        {
+          ...baseReviews[1],
+          id: multiplier + 2,
+          User: {
+            ...baseReviews[1].User,
+            id: baseReviews[1].User.id + multiplier,
+          },
+          Gathering: {
+            ...baseReviews[1].Gathering,
+            id: baseReviews[1].Gathering.id + multiplier,
+          },
+        },
+      ];
+    }).flat();
+
+    const parsedOffset = offset ? parseInt(offset) : 0;
+    const parsedLimit = limit ? parseInt(limit) : 10;
+    const paginatedReviews = reviews.slice(
+      parsedOffset,
+      parsedOffset + parsedLimit,
+    );
+
+    return HttpResponse.json(paginatedReviews);
   }),
 
   http.get(baseUrl('/reviews/scores'), ({ request }) => {

--- a/src/providers/navigation-provider.tsx
+++ b/src/providers/navigation-provider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+import useReviewFilterAtom from '~/src/hooks/reviews/use-review-filter-atom';
+
+export default function NavigationProvider() {
+  const pathname = usePathname();
+  const prevPathname = useRef(pathname);
+
+  const { onResetFilter } = useReviewFilterAtom();
+
+  const isMovedOtherPage = useCallback(
+    (path: string) => {
+      return prevPathname.current === path && pathname !== path;
+    },
+    [pathname],
+  );
+
+  useEffect(() => {
+    if (isMovedOtherPage('/all-reviews')) {
+      onResetFilter();
+    }
+
+    prevPathname.current = pathname;
+  }, [isMovedOtherPage, onResetFilter, pathname]);
+
+  return null;
+}

--- a/src/services/reviews/types.ts
+++ b/src/services/reviews/types.ts
@@ -5,7 +5,7 @@ import {
   type SortOrder,
 } from '~/src/services/types';
 
-type ReviewSortBy = 'createdAt' | 'score' | 'participantCount';
+export type ReviewSortBy = 'createdAt' | 'score' | 'participantCount';
 
 export interface CreateReviewRequest {
   gatheringId: number;
@@ -14,7 +14,7 @@ export interface CreateReviewRequest {
 }
 
 export interface CreateReviewResponse {
-  teamId: number;
+  teamId: string;
   id: number;
   userId: number;
   gatheringId: number;
@@ -37,13 +37,13 @@ export type GetReviewListRequest = Partial<
 >;
 
 export type GetReviewListResponse = Array<{
-  teamId: number;
+  teamId: string;
   id: number;
   score: number;
   comment: string;
   createdAt: string;
   Gathering: {
-    teamId: number;
+    teamId: string;
     id: number;
     type: string;
     name: string;
@@ -52,7 +52,7 @@ export type GetReviewListResponse = Array<{
     image: string;
   };
   User: {
-    teamId: number;
+    teamId: string;
     id: number;
     name: string;
     image: string;
@@ -66,7 +66,7 @@ export type GetReviewScoreRequest = Partial<{
 
 export type GetReviewScoreResponse = [
   {
-    teamId: number;
+    teamId: string;
     gatheringId: number;
     type: GatheringType;
     averageScore: number;

--- a/src/services/reviews/use-get-review-infinite-list.ts
+++ b/src/services/reviews/use-get-review-infinite-list.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 
 import useReviewFilterAtom from '~/src/hooks/reviews/use-review-filter-atom';
 import { get } from '~/src/services/api';
@@ -16,6 +16,7 @@ export default function useGetReviewInfiniteList() {
       get<GetReviewListResponse>('/reviews', {
         params: { ...params, ...pageParam },
       }),
+    placeholderData: keepPreviousData,
     select: ({ pages }) => {
       return pages.flatMap((data) => data);
     },

--- a/src/stores/review-filter-atom.ts
+++ b/src/stores/review-filter-atom.ts
@@ -1,9 +1,10 @@
-import { atom } from 'jotai';
+import { atomWithReset } from 'jotai/utils';
 
 import { type GetReviewListRequest } from '~/src/services/reviews/types';
+import { type PageParam } from '~/src/services/types';
 
-export type ReviewFilter = Omit<GetReviewListRequest, 'limit' | 'offset'>;
+export type ReviewFilter = Omit<GetReviewListRequest, keyof PageParam>;
 
-export const reviewFilterAtom = atom<ReviewFilter>({
+export const reviewFilterAtom = atomWithReset<ReviewFilter>({
   type: 'DALLAEMFIT',
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,15 +1,27 @@
 /**
- * 날짜와 시간을 'YYYY-MM-DDTHH:00:00' 형식의 문자열로 변환합니다.
+ * 날짜와 시간을 'YYYY-MM-DD' 또는 'YYYY-MM-DDTHH:00:00' 형식의 문자열로 변환합니다.
  * @param {Date} date - 변환할 날짜 객체
- * @param {number} time - 시간 (0-23)
- * @returns {string} 'YYYY-MM-DDTHH:00:00' 형식의 날짜/시간 문자열
+ * @param {number} [time] - 시간 (0-23)
+ * @returns {string} 날짜/시간 문자열
  * @example
+ * // 시간 포함
  * getDateForFormData(new Date('2024-12-05'), 15)
  * // returns '2024-12-05T15:00:00'
+ *
+ * // 시간 미포함
+ * getDateForFormData(new Date('2024-12-05'))
+ * // returns '2024-12-05'
  */
-export const getDateForFormData = (date: Date, time: number) => {
-  const formattedDate = date.toISOString().split('T')[0];
-  const formattedTime = time.toString().padStart(2, '0');
+export const getDateForFormData = (date: Date, time?: number) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const formattedDate = `${year}-${month}-${day}`;
 
-  return `${formattedDate}T${formattedTime}:00:00`;
+  if (time) {
+    const formattedTime = time.toString().padStart(2, '0');
+    return `${formattedDate}T${formattedTime}:00:00`;
+  }
+
+  return formattedDate;
 };


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
모든 리뷰 페이지 안된 작업 마무리~!~!
1. 필터링
2. 무한스크롤

## 🎉 변경 사항
### right-filter 컴포넌트에 onDateReset 추가 56b4b1fd031e45e60e5230b29a08c25dfe1624ad
- 초기화 버튼 클릭시에 api 요청하는 필터링도 초기화 되야한다고 생각해서 초기화 시에도 외부에서 함수를 주입할 수 있도록 onDateReset prop 추가했습니다.

### navigation provider 추가 c01249af2e7d115f1b171c5d8ffe5d5b46963373
⚠️ **만든 이유**
1. jotai같은 전역 상태관리로 상태를 관리할때는 라우터 이동시에도 값이 유지됩니다.
2. 페이지 이동시에 전역 상태관리 값을 초기화 하려면 명시적으로 초기화 하는 로직이 필요합니다.
3. pathname이 바뀔때마다 사이드 이펙트가 실행되는 프로바이더를 하나 생성합니다.
4. 라우터가 바뀌어야할때 동작해야할 함수들을 프로바이더 안에서 실행합니다.

### 모든 리뷰 필터링 구현 f8afdb7a3bdde643b9f5a62d5ee4f27a249602b9
- 목데이터에 필터링 구현까지는 귀찮아서,,, 네트워크 탭으로 잘 작동하는지 확인했습니다~

### 모든 리뷰 무한스크롤 구현
- `react-intersection-observer` 설치했습니다. `npm install` 해주세요~!

### 그외
1. api request에 날짜를 보낼때 값을 바꿔주는 유틸 함수 수정 5ddd288d6398dde46c4870d4a96bbfeaa978c3df
2. 리뷰 관련 타입 중에 `teamId`가 `number`로 들어가있는거 `string`으로 수정 217dbecbc3ca2e4b550005f51d033e32d17cb34d
3. 등등...