### PR TITLE
fix: 모임 목록 페이지 수정

### DIFF
--- a/app/all-reviews/page.tsx
+++ b/app/all-reviews/page.tsx
@@ -16,10 +16,17 @@ import { type PageParam } from '~/src/services/types';
 
 export default async function AllReviewsPage() {
   const state = await getDehydratedInfiniteQuery({
-    queryKey: reviewsQueryKeys.reviewInfiniteList({ type: 'DALLAEMFIT' }),
+    queryKey: reviewsQueryKeys.reviewInfiniteList({
+      type: 'DALLAEMFIT',
+      sortBy: 'createdAt',
+    }),
     queryFn: ({ pageParam }) =>
       get<GetReviewListResponse>('/reviews', {
-        params: { type: 'DALLAEMFIT', ...(pageParam as PageParam) },
+        params: {
+          type: 'DALLAEMFIT',
+          sortBy: 'createdAt',
+          ...(pageParam as PageParam),
+        },
       }),
     initialPageParam: { limit: 10, offset: 0 },
   });

--- a/app/gatherings/[id]/page.tsx
+++ b/app/gatherings/[id]/page.tsx
@@ -4,7 +4,7 @@ import MainContainer from '~/src/components/layout/main-container';
 import { get } from '~/src/services/api';
 import { gatheringsQueryKeys } from '~/src/services/gatherings/queryKey';
 import {
-  type GetGatheringDetailResponse,
+  type Gathering,
   type GetGatheringReviewResponse,
 } from '~/src/services/gatherings/types';
 import { getDehydratedQuery, Hydration } from '~/src/services/tanstack-query';
@@ -18,7 +18,7 @@ interface Props {
 export default async function GatheringItemPage({ params }: Props) {
   const detailState = await getDehydratedQuery({
     queryKey: gatheringsQueryKeys.gatheringDetail({ id: Number(params.id) }),
-    queryFn: () => get<GetGatheringDetailResponse>(`/gatherings/${params.id}`),
+    queryFn: () => get<Gathering>(`/gatherings/${params.id}`),
   });
 
   const reviewState = await getDehydratedQuery({

--- a/app/gatherings/page.tsx
+++ b/app/gatherings/page.tsx
@@ -25,11 +25,9 @@ export default async function GatheringsPage() {
       <PageTitleWithImage />
       <div className="flex flex-1 flex-col gap-6">
         <GatheringPanel />
-        <div className="flex flex-1 items-center justify-center">
-          <Hydration state={state}>
-            <CardContainer />
-          </Hydration>
-        </div>
+        <Hydration state={state}>
+          <CardContainer />
+        </Hydration>
       </div>
     </MainContainer>
   );

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -9,9 +9,7 @@ export default function WishlistPage() {
       <PageTitleWithImage />
       <div className="flex flex-1 flex-col gap-6">
         <WishlistPanel />
-        <div className="flex flex-1 items-center justify-center">
-          <WishlistContainer />
-        </div>
+        <WishlistContainer />
       </div>
     </MainContainer>
   );

--- a/src/components/common/left-filter.tsx
+++ b/src/components/common/left-filter.tsx
@@ -54,6 +54,7 @@ export default function LeftFilter({
 
       {isOpen && (
         <Dropdown
+          className="right-0"
           options={options}
           onSelect={selectOption}
           version="Filter"

--- a/src/components/common/progress-bar.tsx
+++ b/src/components/common/progress-bar.tsx
@@ -37,6 +37,10 @@ export default function ProgressBar({
 
   return (
     <div
+      role="progressbar"
+      aria-valuenow={progressPercentage}
+      aria-valuemin={0}
+      aria-valuemax={100}
       className={cn(`relative h-1 w-full rounded-md bg-orange-50`, className)}
     >
       <div

--- a/src/components/gathering-card/card-container.tsx
+++ b/src/components/gathering-card/card-container.tsx
@@ -47,15 +47,17 @@ export default function CardContainer() {
 
   if (!isFetching && (!data || flattenedData.length === 0)) {
     return (
-      <div className="text-center text-sm font-medium text-gray-500">
-        아직 모임이 없어요, <br />
-        지금 바로 모임을 만들어보세요!
+      <div className="flex flex-1 items-center justify-center">
+        <div className="text-center text-sm font-medium text-gray-500">
+          아직 모임이 없어요, <br />
+          지금 바로 모임을 만들어보세요!
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="w-full">
+    <div className="w-full pb-10">
       {breakpoint === 'tablet' || breakpoint === 'desktop' ? (
         <div className="flex flex-col gap-6">
           {flattenedData?.map((gathering) => (

--- a/src/components/gathering-card/gathering-card-large.tsx
+++ b/src/components/gathering-card/gathering-card-large.tsx
@@ -22,8 +22,8 @@ export default function GatheringCardLarge({
 }: GatheringCardProps) {
   const router = useRouter();
   const { isSaved, handleSaveButton, cardState } = useGatheringCard({
-    participantCount: gathering.participantCount ?? 5,
-    capacity: gathering.capacity ?? 20,
+    participantCount: gathering.participantCount,
+    capacity: gathering.capacity,
     gatheringId: gathering.id,
   });
 
@@ -101,8 +101,8 @@ export default function GatheringCardLarge({
             {/* 인원수랑 개설확정 */}
             <div className="flex gap-2">
               <MemberCountChip
-                current={gathering.participantCount || 5}
-                capacity={gathering.capacity || 20}
+                current={gathering.participantCount}
+                capacity={gathering.capacity}
                 className={cardState === 'closed' ? 'text-orange-400' : ''}
               />
               {cardState === 'confirmation' && <Confirmation />}
@@ -134,6 +134,8 @@ export default function GatheringCardLarge({
           </div>
           {isSaved && (
             <SaveBye
+              role="button"
+              aria-label="save-bye"
               className="pointer-events-auto absolute right-4 top-4 cursor-pointer"
               onClick={(e: React.MouseEvent<SVGSVGElement>) => {
                 e.preventDefault();

--- a/src/components/gathering-card/gathering-card-small.tsx
+++ b/src/components/gathering-card/gathering-card-small.tsx
@@ -39,7 +39,7 @@ export default function GatheringCardSmall({
     <div
       {...props}
       onClick={handleClick}
-      className={`relative flex w-full max-w-[343px] flex-col rounded-3xl border-2 border-gray-100 transition-shadow hover:border-gray-200 hover:shadow-card-hover`}
+      className={`relative flex w-full flex-col rounded-3xl border-2 border-gray-100 transition-shadow hover:border-gray-200 hover:shadow-card-hover`}
     >
       {/* 이미지 */}
       <div className="relative h-[156px] w-full flex-shrink-0">

--- a/src/components/gathering-card/gathering-detail-content.tsx
+++ b/src/components/gathering-card/gathering-detail-content.tsx
@@ -20,11 +20,12 @@ export default function GatheringDetailContent({ gatheringId }: Props) {
   return (
     <>
       <GatheringDetailImage
-        image={data[0].image}
+        image={data.image}
         className="h-[180px] tablet:h-60"
+        registrationEnd={data.registrationEnd}
       />
-      <GatheringInfo gathering={data[0]} />
-      <FloatingBar createdById={data[0].createdBy} />
+      <GatheringInfo gathering={data} />
+      <FloatingBar createdById={data.createdBy} />
     </>
   );
 }

--- a/src/components/gathering-card/gathering-detail-image.tsx
+++ b/src/components/gathering-card/gathering-detail-image.tsx
@@ -5,20 +5,32 @@ import { cn } from '~/src/utils/class-name';
 
 interface GatheringDetailImageProps {
   image: string;
+  registrationEnd: string;
   className?: string;
 }
 
 export default function GatheringDetailImage({
   image,
   className,
+  registrationEnd,
 }: GatheringDetailImageProps) {
   return (
     <div
       className={cn(`relative rounded-3xl border border-gray-200`, className)}
     >
-      <Tag size="small" className="absolute right-0 top-0 z-[1]">
-        {'오늘 21시 마감'}
-      </Tag>
+      {/* 오늘이 마감일인 경우에만 Tag 표시 */}
+      {new Date(registrationEnd).toDateString() ===
+        new Date().toDateString() && (
+        <Tag size="small" className="absolute right-0 top-0">
+          오늘{' '}
+          {new Date(registrationEnd).toLocaleTimeString('ko-KR', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+          })}{' '}
+          마감
+        </Tag>
+      )}
       <Image src={image} alt="gathering image" fill className="rounded-3xl" />
     </div>
   );

--- a/src/components/gathering-card/gathering-panel.tsx
+++ b/src/components/gathering-card/gathering-panel.tsx
@@ -20,8 +20,11 @@ export default function GatheringPanel() {
   };
 
   const handleLocationSelect = (option: string) => {
-    console.log('Location selected:', option);
-    setLocation(option as GatheringLocation);
+    if (option === '지역 전체') {
+      setLocation(undefined);
+    } else {
+      setLocation(option as GatheringLocation);
+    }
   };
 
   const handleDateSelect = (date: Date) => {
@@ -41,6 +44,9 @@ export default function GatheringPanel() {
         break;
       case '참여 인원 순':
         sortOption = 'participantCount';
+        break;
+      case '최신 순':
+        sortOption = 'dateTime';
         break;
       default:
         return;
@@ -75,7 +81,7 @@ export default function GatheringPanel() {
           />
         </div>
         <LeftFilter
-          options={['마감 임박', '참여 인원 순']}
+          options={['마감 임박', '참여 인원 순', '최신 순']}
           onOptionSelect={(option) => handleSortBySelect(option)}
         />
       </div>

--- a/src/components/layout/floating-bar.tsx
+++ b/src/components/layout/floating-bar.tsx
@@ -32,19 +32,6 @@ export default function FloatingBar({ createdById }: FloatingBarProps) {
         )}
       >
         {isCreator ? (
-          <div className="flex w-full items-center justify-between">
-            <div className="w-[204px] tablet:w-full">
-              <h2 className="font-semibold">더 건강한 나를 위한 프로그램 🏃</h2>
-              <p className="text-xs">
-                국내 최고 웰리스 전문가와 프로그램을 통해 지친 몸과 마음을
-                회복해봐요
-              </p>
-            </div>
-            <Button className="w-[115px]" type="button">
-              참여하기
-            </Button>
-          </div>
-        ) : (
           <div className="flex w-full flex-col gap-2 tablet:flex-row tablet:justify-between">
             <div className="flex flex-col gap-1">
               <h2 className="font-semibold"> 더 건강한 나를 위한 프로그램🏃</h2>
@@ -60,6 +47,19 @@ export default function FloatingBar({ createdById }: FloatingBarProps) {
                 공유하기
               </Button>
             </div>
+          </div>
+        ) : (
+          <div className="flex w-full items-center justify-between">
+            <div className="w-[204px] tablet:w-full">
+              <h2 className="font-semibold">더 건강한 나를 위한 프로그램 🏃</h2>
+              <p className="text-xs">
+                국내 최고 웰리스 전문가와 프로그램을 통해 지친 몸과 마음을
+                회복해봐요
+              </p>
+            </div>
+            <Button className="w-[115px]" type="button">
+              참여하기
+            </Button>
           </div>
         )}
       </section>

--- a/src/components/reviews/all-reviews-page/review-list.tsx
+++ b/src/components/reviews/all-reviews-page/review-list.tsx
@@ -41,7 +41,7 @@ export default function ReviewList() {
 
       {/* 첫 페칭이 끝나고 데이터 없을때 */}
       {!isFetching && data?.length === 0 && (
-        <div className="flex grow items-center justify-center">
+        <div className="flex grow items-center justify-center py-5">
           <p className="text-sm text-secondary-500">아직 리뷰가 없어요</p>
         </div>
       )}

--- a/src/components/wishlist/wishlist-container.tsx
+++ b/src/components/wishlist/wishlist-container.tsx
@@ -17,8 +17,10 @@ export default function WishlistContainer() {
 
   if (!data || flattenedData.length === 0) {
     return (
-      <div className="text-center text-sm font-medium text-gray-500">
-        아직 찜한 모임이 없어요
+      <div className="flex flex-1 items-center justify-center pb-10">
+        <div className="text-center text-sm font-medium text-gray-500">
+          아직 찜한 모임이 없어요
+        </div>
       </div>
     );
   }

--- a/src/hooks/gatherings/use-gathering-filter.ts
+++ b/src/hooks/gatherings/use-gathering-filter.ts
@@ -10,10 +10,10 @@ import {
 } from '~/src/stores/gathering-filter-atom';
 
 export function useGatheringFilter() {
-  const [type, setType] = useAtom(gatheringTypeAtom);
+  const [type, setType] = useAtom(gatheringTypeAtom || 'DALLAEMFIT');
   const [location, setLocation] = useAtom(gatheringLocationAtom);
   const [date, setDate] = useAtom(gatheringDateAtom);
-  const [sortBy, setSortBy] = useAtom(gatheringSortByAtom);
+  const [sortBy, setSortBy] = useAtom(gatheringSortByAtom || 'registrationEnd');
 
   return {
     type,

--- a/src/services/gatherings/types.ts
+++ b/src/services/gatherings/types.ts
@@ -44,8 +44,6 @@ export interface GetGatheringDetailRequest {
   id: number;
 }
 
-export type GetGatheringDetailResponse = Gathering[];
-
 export interface GetGatheringParticipantsRequest extends Partial<PageParam> {
   gatheringId: number;
 }

--- a/src/services/gatherings/use-gathering-detail.ts
+++ b/src/services/gatherings/use-gathering-detail.ts
@@ -2,13 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { get } from '~/src/services/api';
 import { gatheringsQueryKeys } from '~/src/services/gatherings/queryKey';
-import { type GetGatheringDetailResponse } from '~/src/services/gatherings/types';
+import { type Gathering } from '~/src/services/gatherings/types';
 
 export default function useGatheringDetail(id: number) {
-  return useQuery<GetGatheringDetailResponse>({
+  return useQuery<Gathering>({
     queryKey: gatheringsQueryKeys.gatheringDetail({ id }),
     queryFn: () => {
-      return get<GetGatheringDetailResponse>(`/gatherings/${id}`);
+      return get<Gathering>(`/gatherings/${id}`);
     },
   });
 }

--- a/src/stores/gathering-filter-atom.ts
+++ b/src/stores/gathering-filter-atom.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai';
 
+import { type SortBy } from '~/src/services/gatherings/types';
 import {
   type GatheringLocation,
   type GatheringType,
@@ -11,4 +12,4 @@ export const gatheringLocationAtom = atom<GatheringLocation | undefined>();
 
 export const gatheringDateAtom = atom();
 
-export const gatheringSortByAtom = atom();
+export const gatheringSortByAtom = atom<SortBy>();

--- a/src/stores/review-filter-atom.ts
+++ b/src/stores/review-filter-atom.ts
@@ -7,4 +7,5 @@ export type ReviewFilter = Omit<GetReviewListRequest, keyof PageParam>;
 
 export const reviewFilterAtom = atomWithReset<ReviewFilter>({
   type: 'DALLAEMFIT',
+  sortBy: 'createdAt',
 });

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -2,7 +2,12 @@ export default function formatDateTime(dateTime: string): {
   date: string;
   time: string;
 } {
-  const dateObj = new Date(dateTime);
+  // 시간이 없는 경우 '00:00:00'을 추가
+  const fullDateTime = dateTime.includes('T')
+    ? dateTime
+    : `${dateTime}T00:00:00`;
+
+  const dateObj = new Date(fullDateTime);
 
   const month = dateObj.getMonth() + 1;
   const day = dateObj.getDate();


### PR DESCRIPTION
resolves #113, #114

## 🤔 해결하려는 문제가 무엇인가요?
- [x] 리스트 레이아웃 수정 (개수 적을때 가운데 정렬되는 문제)
- [x] 참가자수 5명 디폴트값 제거 
- [x] 카드 리스트 밑에 패딩값 추가
- [x] 지역을 선택했다가 지역 전체를 누르면 api 요청할때 location값에 지역 전체가 들어가서 안불러와지네요. '지역 전체'일때는 undefined값을 보내야할것 같습니다
- [x] 초기에 필터가 마감 임박으로 되어있는데 api 요청할때는 안들어가 있어서 마감 임박 순으로 안나와요. 초기값 설정하시면 될것 같습니다.
- [x] 피그마 상에는 없는데 스웨거에는 정렬 필터에 최신순도 있네요. 추가해주시면 좋을것 같습니다!
- [x] 상세페이지 이동할때 에러 납니다
- [x] 상세페이지 이미지에 붙은 태그 수정
- [x] leftfilter 오른쪽 정렬 
- [x] 모바일에서 카드 넓게
- [x] 플로팅 바 조건문 반대로 된 거 수정

## 🎉 변경 사항

## 🙏 여기는 꼭 봐주세요!
