### PR TITLE
fix(gathering): 플로팅 바 추가 #117

### DIFF
--- a/src/components/common/button.test.tsx
+++ b/src/components/common/button.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Button from '~/src/components/common/button';
+
+describe('Button Component', () => {
+  it('기본 테스트', () => {
+    render(<Button>버튼</Button>);
+    const button = screen.getByRole('button', { name: /버튼/i });
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass(
+      'w-full rounded-xl px-3 text-white shadow-sm transition-colors duration-75 hover:shadow-md h-[44px] bg-primary-600',
+    );
+  });
+
+  it('outlined 테스트', () => {
+    render(<Button variant="outlined">버튼</Button>);
+    const button = screen.getByRole('button', { name: /버튼/i });
+
+    expect(button).toHaveClass(
+      'border border-primary-600 bg-white text-primary-600 hover:border-primary-700 hover:text-primary-700 active:border-primary-800 active:text-primary-800',
+    );
+  });
+
+  it('비활성화 테스트', () => {
+    render(<Button disabled>버튼</Button>);
+    const button = screen.getByRole('button', { name: /버튼/i });
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass('bg-secondary-400 cursor-not-allowed');
+  });
+
+  it('children이 렌더링 테스트', () => {
+    render(<Button>테스트 버튼</Button>);
+    const button = screen.getByRole('button', { name: /테스트 버튼/i });
+
+    expect(button).toHaveTextContent('테스트 버튼');
+  });
+
+  it('사용자 정의 클래스 적용 테스트', () => {
+    render(<Button className="custom-class">버튼</Button>);
+    const button = screen.getByRole('button', { name: /버튼/i });
+
+    expect(button).toHaveClass('custom-class');
+  });
+});

--- a/src/components/common/cancel-gathering-button.tsx
+++ b/src/components/common/cancel-gathering-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+
+import Button from '~/src/components/common/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/src/components/common/modal';
+import { useCancelGathering } from '~/src/services/gatherings/use-cancel-gathering';
+
+interface CancelGatheringButtonProps {
+  gatheringId: number;
+}
+
+export default function CancelGatheringButton({
+  gatheringId,
+}: CancelGatheringButtonProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const { mutate: cancelGathering } = useCancelGathering();
+
+  const handleCancelGathering = () => {
+    cancelGathering(gatheringId);
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="flex h-[212px] flex-col items-center justify-between gap-0 p-6 text-center">
+          <DialogHeader>
+            <DialogTitle></DialogTitle>
+          </DialogHeader>
+          <p>정말 모임을 취소하시겠습니까?</p>
+
+          <DialogFooter className="flex w-full justify-end">
+            <Button
+              className="w-[120px]"
+              type="button"
+              onClick={handleCancelGathering}
+            >
+              확인
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Button
+        onClick={() => setIsDialogOpen(true)}
+        type="button"
+        variant="outlined"
+      >
+        취소하기
+      </Button>
+    </>
+  );
+}

--- a/src/components/common/cancel-gathering-button.tsx
+++ b/src/components/common/cancel-gathering-button.tsx
@@ -9,6 +9,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from '~/src/components/common/modal';
 import { useCancelGathering } from '~/src/services/gatherings/use-cancel-gathering';
 
@@ -29,32 +30,28 @@ export default function CancelGatheringButton({
   };
 
   return (
-    <>
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="opacity-0"> 모임 취소하기 </DialogTitle>
-          </DialogHeader>
-          <p className="flex justify-center">정말 모임을 취소하시겠습니까?</p>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outlined" className="w-full">
+          취소하기
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="opacity-0"> 모임 취소하기 </DialogTitle>
+        </DialogHeader>
+        <p className="flex justify-center">정말 모임을 취소하시겠습니까?</p>
 
-          <DialogFooter className="flex w-full justify-end">
-            <Button
-              className="w-[120px]"
-              type="button"
-              onClick={handleCancelGathering}
-            >
-              확인
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <Button
-        type="button"
-        variant="outlined"
-        onClick={() => setIsDialogOpen(true)}
-      >
-        취소하기
-      </Button>
-    </>
+        <DialogFooter className="flex w-full justify-end">
+          <Button
+            className="w-[120px]"
+            type="button"
+            onClick={handleCancelGathering}
+          >
+            확인
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/common/cancel-gathering-button.tsx
+++ b/src/components/common/cancel-gathering-button.tsx
@@ -31,11 +31,11 @@ export default function CancelGatheringButton({
   return (
     <>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent className="flex h-[212px] flex-col items-center justify-between gap-0 p-6 text-center">
+        <DialogContent>
           <DialogHeader>
-            <DialogTitle></DialogTitle>
+            <DialogTitle className="opacity-0"> 모임 취소하기 </DialogTitle>
           </DialogHeader>
-          <p>정말 모임을 취소하시겠습니까?</p>
+          <p className="flex justify-center">정말 모임을 취소하시겠습니까?</p>
 
           <DialogFooter className="flex w-full justify-end">
             <Button
@@ -48,11 +48,10 @@ export default function CancelGatheringButton({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
       <Button
-        onClick={() => setIsDialogOpen(true)}
         type="button"
         variant="outlined"
+        onClick={() => setIsDialogOpen(true)}
       >
         취소하기
       </Button>

--- a/src/components/common/join-toggle-button.tsx
+++ b/src/components/common/join-toggle-button.tsx
@@ -31,6 +31,7 @@ export default function JoinButton({
   const [open, setOpen] = useState(false);
   const [user] = useAtom(userInfoAtom);
   const router = useRouter();
+
   const handleJoin = () => {
     joinGathering(gatheringId);
   };
@@ -51,6 +52,7 @@ export default function JoinButton({
           <Button
             className="w-[115px]"
             type="button"
+            variant="outlined"
             onClick={handleConfirmCancel}
           >
             취소하기

--- a/src/components/common/join-toggle-button.tsx
+++ b/src/components/common/join-toggle-button.tsx
@@ -9,7 +9,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '~/src/components/common/modal';
 import { useJoinGathering } from '~/src/services/gatherings/use-join-gathering';
 import { useLeaveGathering } from '~/src/services/gatherings/use-leave-gathering';
@@ -43,12 +42,13 @@ export default function JoinButton({
   return (
     <>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogTrigger> </DialogTrigger>
-        <DialogContent className="flex h-[212px] flex-col items-center justify-between gap-0 p-6 text-center">
+        <DialogContent>
           <DialogHeader>
-            <DialogTitle></DialogTitle>
+            <DialogTitle className="opacity-0"> 모임 나가기 </DialogTitle>
           </DialogHeader>
-          <p>정말 모임 참여를 취소하시겠습니까?</p>
+          <p className="flex justify-center">
+            정말 모임 참여를 취소하시겠습니까?
+          </p>
 
           <DialogFooter className="flex w-full justify-end">
             <Button
@@ -61,7 +61,6 @@ export default function JoinButton({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
       <Button className="w-[115px]" type="button" onClick={handleJoinToggle}>
         {isParticipant ? '취소하기' : '참여하기'}
       </Button>

--- a/src/components/common/join-toggle-button.tsx
+++ b/src/components/common/join-toggle-button.tsx
@@ -9,6 +9,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from '~/src/components/common/modal';
 import { useJoinGathering } from '~/src/services/gatherings/use-join-gathering';
 import { useLeaveGathering } from '~/src/services/gatherings/use-leave-gathering';
@@ -24,46 +25,47 @@ export default function JoinButton({
 }: JoinButtonProps) {
   const { mutate: joinGathering } = useJoinGathering();
   const { mutate: leaveGathering } = useLeaveGathering();
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [open, setOpen] = useState(false);
 
-  const handleJoinToggle = () => {
-    if (isParticipant) {
-      setIsDialogOpen(true);
-    } else {
-      joinGathering(gatheringId);
-    }
+  const handleJoin = () => {
+    joinGathering(gatheringId);
   };
 
-  const handleDialogConfirm = () => {
+  const handleConfirmCancel = () => {
     leaveGathering(gatheringId);
-    setIsDialogOpen(false);
+    setOpen(false);
   };
 
   return (
     <>
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="opacity-0"> 모임 나가기 </DialogTitle>
-          </DialogHeader>
-          <p className="flex justify-center">
-            정말 모임 참여를 취소하시겠습니까?
-          </p>
-
-          <DialogFooter className="flex w-full justify-end">
-            <Button
-              className="w-[120px]"
-              type="button"
-              onClick={handleDialogConfirm}
-            >
-              확인
+      {isParticipant ? (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outlined" className="w-[115px]" type="button">
+              취소하기
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <Button className="w-[115px]" type="button" onClick={handleJoinToggle}>
-        {isParticipant ? '취소하기' : '참여하기'}
-      </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle className="opacity-0">모임 취소하기</DialogTitle>
+            </DialogHeader>
+            <p className="flex justify-center">정말 모임을 취소하시겠습니까?</p>
+            <DialogFooter className="flex w-full justify-end">
+              <Button
+                className="w-[120px]"
+                type="button"
+                onClick={handleConfirmCancel}
+              >
+                확인
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <Button className="w-[115px]" type="button" onClick={handleJoin}>
+          참여하기
+        </Button>
+      )}
     </>
   );
 }

--- a/src/components/common/join-toggle-button.tsx
+++ b/src/components/common/join-toggle-button.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+
+import Button from '~/src/components/common/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/src/components/common/modal';
+import { useJoinGathering } from '~/src/services/gatherings/use-join-gathering';
+import { useLeaveGathering } from '~/src/services/gatherings/use-leave-gathering';
+
+interface JoinButtonProps {
+  gatheringId: number;
+  isParticipant: boolean;
+}
+
+export default function JoinButton({
+  gatheringId,
+  isParticipant,
+}: JoinButtonProps) {
+  const { mutate: joinGathering } = useJoinGathering();
+  const { mutate: leaveGathering } = useLeaveGathering();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleJoinToggle = () => {
+    if (isParticipant) {
+      setIsDialogOpen(true);
+    } else {
+      joinGathering(gatheringId);
+    }
+  };
+
+  const handleDialogConfirm = () => {
+    leaveGathering(gatheringId);
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger> </DialogTrigger>
+        <DialogContent className="flex h-[212px] flex-col items-center justify-between gap-0 p-6 text-center">
+          <DialogHeader>
+            <DialogTitle></DialogTitle>
+          </DialogHeader>
+          <p>정말 모임 참여를 취소하시겠습니까?</p>
+
+          <DialogFooter className="flex w-full justify-end">
+            <Button
+              className="w-[120px]"
+              type="button"
+              onClick={handleDialogConfirm}
+            >
+              확인
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Button className="w-[115px]" type="button" onClick={handleJoinToggle}>
+        {isParticipant ? '취소하기' : '참여하기'}
+      </Button>
+    </>
+  );
+}

--- a/src/components/common/join-toggle-button.tsx
+++ b/src/components/common/join-toggle-button.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAtom } from 'jotai';
 
 import Button from '~/src/components/common/button';
 import {
@@ -13,6 +15,7 @@ import {
 } from '~/src/components/common/modal';
 import { useJoinGathering } from '~/src/services/gatherings/use-join-gathering';
 import { useLeaveGathering } from '~/src/services/gatherings/use-leave-gathering';
+import { userInfoAtom } from '~/src/stores/auth-store';
 
 interface JoinButtonProps {
   gatheringId: number;
@@ -26,7 +29,8 @@ export default function JoinButton({
   const { mutate: joinGathering } = useJoinGathering();
   const { mutate: leaveGathering } = useLeaveGathering();
   const [open, setOpen] = useState(false);
-
+  const [user] = useAtom(userInfoAtom);
+  const router = useRouter();
   const handleJoin = () => {
     joinGathering(gatheringId);
   };
@@ -36,35 +40,49 @@ export default function JoinButton({
     setOpen(false);
   };
 
+  const handleLoginSuccess = () => {
+    setOpen(false);
+    router.push('/login');
+  };
   return (
     <>
-      {isParticipant ? (
+      {user ? (
+        isParticipant ? (
+          <Button
+            className="w-[115px]"
+            type="button"
+            onClick={handleConfirmCancel}
+          >
+            취소하기
+          </Button>
+        ) : (
+          <Button className="w-[115px]" type="button" onClick={handleJoin}>
+            참여하기
+          </Button>
+        )
+      ) : (
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
-            <Button variant="outlined" className="w-[115px]" type="button">
-              취소하기
+            <Button className="w-[115px]" type="button">
+              참여하기
             </Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle className="opacity-0">모임 취소하기</DialogTitle>
+              <DialogTitle className="opacity-0">로그인</DialogTitle>
             </DialogHeader>
-            <p className="flex justify-center">정말 모임을 취소하시겠습니까?</p>
+            <p className="flex justify-center">로그인이 필요합니다.</p>
             <DialogFooter className="flex w-full justify-end">
               <Button
                 className="w-[120px]"
                 type="button"
-                onClick={handleConfirmCancel}
+                onClick={handleLoginSuccess}
               >
                 확인
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      ) : (
-        <Button className="w-[115px]" type="button" onClick={handleJoin}>
-          참여하기
-        </Button>
       )}
     </>
   );

--- a/src/components/common/join-toggle-button.tsx
+++ b/src/components/common/join-toggle-button.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '~/src/components/common/modal';
+import useCustomParams from '~/src/hooks/use-custom-params';
 import { useJoinGathering } from '~/src/services/gatherings/use-join-gathering';
 import { useLeaveGathering } from '~/src/services/gatherings/use-leave-gathering';
 import { userInfoAtom } from '~/src/stores/auth-store';
@@ -32,6 +33,16 @@ export default function JoinButton({
   const [user] = useAtom(userInfoAtom);
   const router = useRouter();
 
+  const { createUrl } = useCustomParams();
+
+  const handleClickLogin = () => {
+    router.push(
+      createUrl('/login', {
+        callback: `gatherings/${gatheringId}`,
+        open: 'true',
+      }),
+    );
+  };
   const handleJoin = () => {
     joinGathering(gatheringId);
   };
@@ -41,10 +52,6 @@ export default function JoinButton({
     setOpen(false);
   };
 
-  const handleLoginSuccess = () => {
-    setOpen(false);
-    router.push('/login');
-  };
   return (
     <>
       {user ? (
@@ -73,12 +80,12 @@ export default function JoinButton({
             <DialogHeader>
               <DialogTitle className="opacity-0">로그인</DialogTitle>
             </DialogHeader>
-            <p className="flex justify-center">로그인이 필요합니다.</p>
+            <p className="flex justify-center">로그인이 필요해요.</p>
             <DialogFooter className="flex w-full justify-end">
               <Button
                 className="w-[120px]"
                 type="button"
-                onClick={handleLoginSuccess}
+                onClick={handleClickLogin}
               >
                 확인
               </Button>

--- a/src/components/common/profile-dropdown.tsx
+++ b/src/components/common/profile-dropdown.tsx
@@ -69,20 +69,25 @@ export default function ProfileDropdown() {
       )}
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent className="flex h-[199px] w-[300px] flex-col items-center justify-between gap-0 p-6 text-center tablet:h-[188px] tablet:w-[450px]">
+        <DialogContent className="h-[199px] w-[300px] tablet:h-[188px] tablet:w-[450px]">
           <DialogHeader>
-            <DialogTitle></DialogTitle>
+            <DialogTitle className="opacity-0"> 로그아웃 </DialogTitle>
           </DialogHeader>
-          <p>로그아웃 하시겠습니까?</p>
-          <DialogFooter className="flex w-[249px] justify-end gap-4">
+          <p className="flex justify-center">로그아웃 하시겠습니까?</p>
+          <DialogFooter className="flex w-full justify-center gap-4">
             <Button
+              className="w-[120px]"
               type="button"
               variant="outlined"
               onClick={handleDialogClose}
             >
               취소
             </Button>
-            <Button type="button" onClick={handleLogoutConfirm}>
+            <Button
+              type="button"
+              className="w-[120px]"
+              onClick={handleLogoutConfirm}
+            >
               {' '}
               확인{' '}
             </Button>

--- a/src/components/gathering-card/gathering-detail-content.tsx
+++ b/src/components/gathering-card/gathering-detail-content.tsx
@@ -25,7 +25,7 @@ export default function GatheringDetailContent({ gatheringId }: Props) {
         registrationEnd={data.registrationEnd}
       />
       <GatheringInfo gathering={data} />
-      <FloatingBar createdById={data.createdBy} />
+      <FloatingBar gathering={data} />
     </>
   );
 }

--- a/src/components/layout/floating-bar.tsx
+++ b/src/components/layout/floating-bar.tsx
@@ -1,19 +1,27 @@
-'use client';
-
 import { useAtom } from 'jotai';
 import { toast } from 'sonner';
 
 import Button from '~/src/components/common/button';
+import CancelGatheringButton from '~/src/components/common/cancel-gathering-button';
+import JoinButton from '~/src/components/common/join-toggle-button';
+import { type Gathering } from '~/src/services/gatherings/types';
+import useJoinedGathering from '~/src/services/gatherings/use-joined-gathering';
 import { userInfoAtom } from '~/src/stores/auth-store';
 import { cn } from '~/src/utils/class-name';
 
 interface FloatingBarProps {
-  createdById: number;
+  gathering: Gathering;
 }
 
-export default function FloatingBar({ createdById }: FloatingBarProps) {
+export default function FloatingBar({ gathering }: FloatingBarProps) {
   const [user] = useAtom(userInfoAtom);
-  const isCreator = user?.id === createdById;
+  const { data: joinedGathering } = useJoinedGathering();
+
+  const isCreator = user?.id === gathering.createdBy;
+  const isParticipant =
+    joinedGathering?.some(
+      (joined: { id: number }) => joined.id === gathering.id,
+    ) ?? false;
 
   const handleShare = () => {
     if (typeof window !== 'undefined') {
@@ -40,9 +48,7 @@ export default function FloatingBar({ createdById }: FloatingBarProps) {
               </p>
             </div>
             <div className="flex w-full gap-2 tablet:w-[238px]">
-              <Button variant="outlined" type="button">
-                취소하기
-              </Button>
+              <CancelGatheringButton gatheringId={gathering.id} />
               <Button type="button" onClick={handleShare}>
                 공유하기
               </Button>
@@ -57,9 +63,10 @@ export default function FloatingBar({ createdById }: FloatingBarProps) {
                 회복해봐요
               </p>
             </div>
-            <Button className="w-[115px]" type="button">
-              참여하기
-            </Button>
+            <JoinButton
+              gatheringId={gathering.id}
+              isParticipant={isParticipant}
+            />
           </div>
         )}
       </section>

--- a/src/components/layout/floating-bar.tsx
+++ b/src/components/layout/floating-bar.tsx
@@ -49,7 +49,7 @@ export default function FloatingBar({ gathering }: FloatingBarProps) {
             </div>
             <div className="flex w-full gap-2 tablet:w-[238px]">
               <CancelGatheringButton gatheringId={gathering.id} />
-              <Button type="button" onClick={handleShare}>
+              <Button type="button" onClick={handleShare} className="w-full">
                 공유하기
               </Button>
             </div>

--- a/src/components/layout/floating-bar.tsx
+++ b/src/components/layout/floating-bar.tsx
@@ -63,6 +63,7 @@ export default function FloatingBar({ gathering }: FloatingBarProps) {
                 회복해봐요
               </p>
             </div>
+
             <JoinButton
               gatheringId={gathering.id}
               isParticipant={isParticipant}

--- a/src/providers/toast-provider.tsx
+++ b/src/providers/toast-provider.tsx
@@ -3,5 +3,5 @@
 import { Toaster } from 'sonner';
 
 export default function ToastProvider() {
-  return <Toaster richColors className="z-[100]" />;
+  return <Toaster position="top-right" richColors className="z-[100]" />;
 }

--- a/src/services/auths/get-user.ts
+++ b/src/services/auths/get-user.ts
@@ -1,16 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
+import { useAtom } from 'jotai';
 
 import { get } from '~/src/services/api';
 import { type ErrorResponseData, type User } from '~/src/services/auths/types';
+import { accessTokenAtom } from '~/src/stores/auth-store';
 
 export function useGetUserInfo() {
+  const [token] = useAtom(accessTokenAtom);
   const { refetch, ...query } = useQuery<User, ErrorResponseData>({
     queryKey: ['user'],
     queryFn: async () => {
       const response = await get<User>('/auths/user');
       return response;
     },
-    enabled: false,
+    enabled: !!token,
   });
   const refetchUser = async () => {
     const { data } = await refetch();

--- a/src/services/gatherings/use-cancel-gathering.ts
+++ b/src/services/gatherings/use-cancel-gathering.ts
@@ -15,7 +15,8 @@ export function useCancelGathering() {
     onSuccess: (data) => {
       console.log(data);
       toast.success('모임이 취소되었습니다.');
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['gathering'] });
+      queryClient.invalidateQueries({ queryKey: ['joinedGathering'] });
       router.push('/');
     },
     onError: (error) => {

--- a/src/services/gatherings/use-cancel-gathering.ts
+++ b/src/services/gatherings/use-cancel-gathering.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import { put } from '~/src/services/api';
 import { type ErrorResponseData } from '~/src/services/auths/types';
+import { gatheringsQueryKeys } from '~/src/services/gatherings/queryKey';
 import { type JoinedGathering } from '~/src/services/gatherings/types';
 
 export function useCancelGathering() {
@@ -12,11 +13,16 @@ export function useCancelGathering() {
   return useMutation<JoinedGathering, ErrorResponseData, number>({
     mutationFn: (gatheringId: number) =>
       put<JoinedGathering>(`/gatherings/${gatheringId}/cancel`),
-    onSuccess: (data) => {
-      console.log(data);
+    onSuccess: (_data, gatheringId) => {
       toast.success('모임이 취소되었습니다.');
-      queryClient.invalidateQueries({ queryKey: ['gathering'] });
       queryClient.invalidateQueries({ queryKey: ['joinedGathering'] });
+      queryClient.invalidateQueries({
+        queryKey: gatheringsQueryKeys.gatheringParticipants({ gatheringId }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: gatheringsQueryKeys.gatheringDetail({ id: gatheringId }),
+      });
       router.push('/');
     },
     onError: (error) => {

--- a/src/services/gatherings/use-cancel-gathering.ts
+++ b/src/services/gatherings/use-cancel-gathering.ts
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/navigation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { put } from '~/src/services/api';
+import { type ErrorResponseData } from '~/src/services/auths/types';
+import { type JoinedGathering } from '~/src/services/gatherings/types';
+
+export function useCancelGathering() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  return useMutation<JoinedGathering, ErrorResponseData, number>({
+    mutationFn: (gatheringId: number) =>
+      put<JoinedGathering>(`/gatherings/${gatheringId}/cancel`),
+    onSuccess: (data) => {
+      console.log(data);
+      toast.success('모임이 취소되었습니다.');
+      queryClient.invalidateQueries();
+      router.push('/');
+    },
+    onError: (error) => {
+      console.log(error);
+      toast.error('모임 취소에 실패했습니다.');
+    },
+  });
+}

--- a/src/services/gatherings/use-join-gathering.ts
+++ b/src/services/gatherings/use-join-gathering.ts
@@ -7,15 +7,30 @@ import { type JoinedGathering } from '~/src/services/gatherings/types';
 
 export function useJoinGathering() {
   const queryClient = useQueryClient();
+
   return useMutation<JoinedGathering, ErrorResponseData, number>({
     mutationFn: (gatheringId: number) =>
       post<JoinedGathering>(`/gatherings/${gatheringId}/join`),
     onSuccess: () => {
-      toast.success('모임에 성공적으로 참여했습니다.');
-      queryClient.invalidateQueries();
+      toast.success('모임에 참여했습니다.');
+
+      queryClient.invalidateQueries({ queryKey: ['gathering'] });
+      queryClient.invalidateQueries({ queryKey: ['joinedGathering'] });
     },
-    onError: () => {
-      toast.error('모임 참여에 실패했습니다.');
+    onError: (error) => {
+      switch (error.data.code) {
+        case 'GATHERING_CANCELED':
+          toast.error('취소된 모임입니다.');
+          break;
+        case 'UNAUTHORIZED':
+          toast.error('로그인이 필요합니다.');
+          break;
+        case 'NOT_FOUND':
+          toast.error('모임을 찾을 수 없습니다.');
+          break;
+        default:
+          toast.error('모임 참여에 실패했습니다.');
+      }
     },
   });
 }

--- a/src/services/gatherings/use-join-gathering.ts
+++ b/src/services/gatherings/use-join-gathering.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { post } from '~/src/services/api';
+import { type ErrorResponseData } from '~/src/services/auths/types';
+import { type JoinedGathering } from '~/src/services/gatherings/types';
+
+export function useJoinGathering() {
+  const queryClient = useQueryClient();
+  return useMutation<JoinedGathering, ErrorResponseData, number>({
+    mutationFn: (gatheringId: number) =>
+      post<JoinedGathering>(`/gatherings/${gatheringId}/join`),
+    onSuccess: () => {
+      toast.success('모임에 성공적으로 참여했습니다.');
+      queryClient.invalidateQueries();
+    },
+    onError: () => {
+      toast.error('모임 참여에 실패했습니다.');
+    },
+  });
+}

--- a/src/services/gatherings/use-join-gathering.ts
+++ b/src/services/gatherings/use-join-gathering.ts
@@ -3,19 +3,25 @@ import { toast } from 'sonner';
 
 import { post } from '~/src/services/api';
 import { type ErrorResponseData } from '~/src/services/auths/types';
+import { gatheringsQueryKeys } from '~/src/services/gatherings/queryKey';
 import { type JoinedGathering } from '~/src/services/gatherings/types';
-
 export function useJoinGathering() {
   const queryClient = useQueryClient();
 
   return useMutation<JoinedGathering, ErrorResponseData, number>({
     mutationFn: (gatheringId: number) =>
       post<JoinedGathering>(`/gatherings/${gatheringId}/join`),
-    onSuccess: () => {
+    onSuccess: (_data, gatheringId) => {
       toast.success('모임에 참여했습니다.');
 
-      queryClient.invalidateQueries({ queryKey: ['gathering'] });
       queryClient.invalidateQueries({ queryKey: ['joinedGathering'] });
+      queryClient.invalidateQueries({
+        queryKey: gatheringsQueryKeys.gatheringParticipants({ gatheringId }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: gatheringsQueryKeys.gatheringDetail({ id: gatheringId }),
+      });
     },
     onError: (error) => {
       switch (error.data.code) {

--- a/src/services/gatherings/use-joined-gathering.ts
+++ b/src/services/gatherings/use-joined-gathering.ts
@@ -1,11 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
+import { useAtom } from 'jotai';
 
 import { get } from '~/src/services/api';
 import { type JoinedGathering } from '~/src/services/gatherings/types';
-
+import { userInfoAtom } from '~/src/stores/auth-store';
 export default function useJoinedGathering() {
+  const [user] = useAtom(userInfoAtom);
+
   const queryResult = useQuery<JoinedGathering[]>({
     queryKey: ['joinedGathering'],
+    enabled: !!user,
     queryFn: async () => {
       const response = await get<JoinedGathering[]>('/gatherings/joined');
       return response;

--- a/src/services/gatherings/use-joined-gathering.ts
+++ b/src/services/gatherings/use-joined-gathering.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { get } from '~/src/services/api';
+import { type JoinedGathering } from '~/src/services/gatherings/types';
+
+export default function useJoinedGathering() {
+  const queryResult = useQuery<JoinedGathering[]>({
+    queryKey: ['joinedGathering'],
+    queryFn: async () => {
+      const response = await get<JoinedGathering[]>('/gatherings/joined');
+      return response;
+    },
+  });
+
+  return queryResult;
+}

--- a/src/services/gatherings/use-leave-gathering.ts
+++ b/src/services/gatherings/use-leave-gathering.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 
 import { del } from '~/src/services/api';
 import { type ErrorResponseData } from '~/src/services/auths/types';
+import { gatheringsQueryKeys } from '~/src/services/gatherings/queryKey';
 import { type JoinedGathering } from '~/src/services/gatherings/types';
 
 export function useLeaveGathering() {
@@ -10,11 +11,16 @@ export function useLeaveGathering() {
   return useMutation<JoinedGathering, ErrorResponseData, number>({
     mutationFn: (gatheringId: number) =>
       del<JoinedGathering>(`/gatherings/${gatheringId}/leave`),
-    onSuccess: (data) => {
-      console.log(data);
+    onSuccess: (_data, gatheringId) => {
       toast.success('모임 참여를 취소했습니다.');
-      queryClient.invalidateQueries({ queryKey: ['gathering'] });
       queryClient.invalidateQueries({ queryKey: ['joinedGathering'] });
+      queryClient.invalidateQueries({
+        queryKey: gatheringsQueryKeys.gatheringParticipants({ gatheringId }),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: gatheringsQueryKeys.gatheringDetail({ id: gatheringId }),
+      });
     },
     onError: (error) => {
       switch (error.data.code) {

--- a/src/services/gatherings/use-leave-gathering.ts
+++ b/src/services/gatherings/use-leave-gathering.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { del } from '~/src/services/api';
+import { type ErrorResponseData } from '~/src/services/auths/types';
+import { type JoinedGathering } from '~/src/services/gatherings/types';
+
+export function useLeaveGathering() {
+  const queryClient = useQueryClient();
+  return useMutation<JoinedGathering, ErrorResponseData, number>({
+    mutationFn: (gatheringId: number) =>
+      del<JoinedGathering>(`/gatherings/${gatheringId}/leave`),
+    onSuccess: (data) => {
+      console.log(data);
+      toast.success('모임 참여를 취소했습니다.');
+      queryClient.invalidateQueries();
+    },
+    onError: (error) => {
+      console.log(error);
+      toast.error('모임 참여 취소에 실패했습니다.');
+    },
+  });
+}

--- a/src/services/gatherings/use-leave-gathering.ts
+++ b/src/services/gatherings/use-leave-gathering.ts
@@ -13,11 +13,23 @@ export function useLeaveGathering() {
     onSuccess: (data) => {
       console.log(data);
       toast.success('모임 참여를 취소했습니다.');
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['gathering'] });
+      queryClient.invalidateQueries({ queryKey: ['joinedGathering'] });
     },
     onError: (error) => {
-      console.log(error);
-      toast.error('모임 참여 취소에 실패했습니다.');
+      switch (error.data.code) {
+        case 'GATHERING_CANCELED':
+          toast.error('취소된 모임입니다.');
+          break;
+        case 'UNAUTHORIZED':
+          toast.error('로그인이 필요합니다.');
+          break;
+        case 'NOT_FOUND':
+          toast.error('모임을 찾을 수 없습니다.');
+          break;
+        default:
+          toast.error('모임 참여를 취소에 실패했습니다.');
+      }
     },
   });
 }

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -14,7 +14,7 @@ export const setAccessTokenAtom = atom(
       Cookies.set('accessToken', newToken, {
         secure: true, // HTTPS 에서만
         sameSite: 'strict', // CSRF
-        expires: 1 / 24,
+        maxAge: 3600,
       });
     } else {
       Cookies.remove('accessToken');
@@ -41,7 +41,7 @@ export const setUserInfoAtom = atom(
       Cookies.set('userInfo', JSON.stringify(newUserInfo), {
         secure: true,
         sameSite: 'strict',
-        expires: 1 / 24,
+        maxAge: 3600,
       });
     } else {
       Cookies.remove('userInfo');


### PR DESCRIPTION
플로팅 바에 참여하기 / 취소하기 / 모임 취소하기 기능 추가했습니다 

현재 로그인 된 사용자가 참여하고있는 모임들 중에서 모임 아이디와 현재 보고있는 모임 상세페이지 아이디가 같은지 확인하고 참여하기와 취소하기 버튼이 다르게 표시되고 

작성자일 때는 모임을 취소할 수있는 버튼 기능입니당 

취소하기 진행할 땐 모달로 재확인 가능하게 해두었습니다. 

플로팅 바에서 작성자 아이디만 가져오는 방식이었다가 여러 기능 추가로 인해서 prop 받는 것도 변경했습니다 