### PR TITLE
test: 테스트 전역 모킹 설정 및 테스트 작성

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -92,6 +92,8 @@ const config: Config = {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/$1',
+    '^.+\\.(svg)$': '<rootDir>/src/mocks/svgrMock.js',
+    '\\.(jpg|jpeg|png|gif|webp)$': '<rootDir>/src/mocks/fileMock.js',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+// Next.js 라우터 전역 모킹
+jest.mock('next/navigation', () => ({
+  useRouter() {
+    return {
+      push: jest.fn(),
+      replace: jest.fn(),
+      prefetch: jest.fn(),
+      back: jest.fn(),
+      refresh: jest.fn(),
+      forward: jest.fn(),
+      pathname: '',
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@svgr/webpack": "^8.1.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^20",
@@ -6702,6 +6703,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.7.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns-tz": "^3.2.0",
         "jotai": "^2.10.3",
         "js-cookie": "^3.0.5",
         "next": "14.2.18",
@@ -9877,6 +9878,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@svgr/webpack": "^8.1.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "axios": "^1.7.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns-tz": "^3.2.0",
     "jotai": "^2.10.3",
     "js-cookie": "^3.0.5",
     "next": "14.2.18",

--- a/src/components/common/chip-info.test.tsx
+++ b/src/components/common/chip-info.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+
+import ChipInfo from '~/src/components/common/chip-info';
+
+describe('ChipInfo 컴포넌트', () => {
+  it('date 타입일 때 흰색 텍스트로 렌더링되어야 함', () => {
+    render(<ChipInfo type="date">2024.03.15</ChipInfo>);
+
+    const chip = screen.getByText('2024.03.15');
+    expect(chip).toHaveClass('text-white');
+  });
+
+  it('time 타입일 때 주황색 텍스트로 렌더링되어야 함', () => {
+    render(<ChipInfo type="time">14:00</ChipInfo>);
+
+    const chip = screen.getByText('14:00');
+    expect(chip).toHaveClass('text-orange-600');
+  });
+
+  it('추가 className이 적용되어야 함', () => {
+    const customClass = 'custom-class';
+    render(
+      <ChipInfo type="date" className={customClass}>
+        2024.03.15
+      </ChipInfo>,
+    );
+
+    const chip = screen.getByText('2024.03.15');
+    expect(chip).toHaveClass(customClass);
+  });
+
+  it('children이 올바르게 렌더링되어야 함', () => {
+    const testContent = '테스트 내용';
+    render(<ChipInfo type="date">{testContent}</ChipInfo>);
+
+    expect(screen.getByText(testContent)).toBeInTheDocument();
+  });
+});

--- a/src/components/common/chip-info.test.tsx
+++ b/src/components/common/chip-info.test.tsx
@@ -4,16 +4,18 @@ import ChipInfo from '~/src/components/common/chip-info';
 
 describe('ChipInfo 컴포넌트', () => {
   it('date 타입일 때 흰색 텍스트로 렌더링되어야 함', () => {
-    render(<ChipInfo type="date">2024.03.15</ChipInfo>);
+    const date = '3월 15일';
+    render(<ChipInfo type="date">{date}</ChipInfo>);
 
-    const chip = screen.getByText('2024.03.15');
+    const chip = screen.getByText(date);
     expect(chip).toHaveClass('text-white');
   });
 
   it('time 타입일 때 주황색 텍스트로 렌더링되어야 함', () => {
-    render(<ChipInfo type="time">14:00</ChipInfo>);
+    const time = '14:00';
+    render(<ChipInfo type="time">{time}</ChipInfo>);
 
-    const chip = screen.getByText('14:00');
+    const chip = screen.getByText(time);
     expect(chip).toHaveClass('text-orange-600');
   });
 
@@ -21,18 +23,11 @@ describe('ChipInfo 컴포넌트', () => {
     const customClass = 'custom-class';
     render(
       <ChipInfo type="date" className={customClass}>
-        2024.03.15
+        3월 15일
       </ChipInfo>,
     );
 
-    const chip = screen.getByText('2024.03.15');
+    const chip = screen.getByText('3월 15일');
     expect(chip).toHaveClass(customClass);
-  });
-
-  it('children이 올바르게 렌더링되어야 함', () => {
-    const testContent = '테스트 내용';
-    render(<ChipInfo type="date">{testContent}</ChipInfo>);
-
-    expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 });

--- a/src/components/common/member-count-chip.test.tsx
+++ b/src/components/common/member-count-chip.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import MemberCountChip from '~/src/components/common/member-count-chip';
+
+jest.mock('~/src/hooks/gatherings/use-count-animation', () => ({
+  useCountAnimation: (value: number) => value,
+}));
+
+describe('MemberCountChip 컴포넌트', () => {
+  it('현재 인원수와 정원이 렌더링되어야 함', () => {
+    render(<MemberCountChip current={5} capacity={20} />);
+    expect(screen.getByText('5/20')).toBeInTheDocument();
+  });
+
+  it('className prop이 적용되어야 함', () => {
+    render(
+      <MemberCountChip current={5} capacity={20} className="custom-class" />,
+    );
+
+    const chip = screen.getByText('5/20').parentElement;
+    expect(chip).toHaveClass('custom-class');
+  });
+});

--- a/src/components/common/progress-bar.test.tsx
+++ b/src/components/common/progress-bar.test.tsx
@@ -1,0 +1,128 @@
+import { act, render, screen } from '@testing-library/react';
+
+import ProgressBar from '~/src/components/common/progress-bar';
+
+jest.mock('~/src/utils/class-name', () => ({
+  cn: (...classes: string[]) => classes.join(' '),
+}));
+
+describe('ProgressBar 컴포넌트', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('기본 렌더링이 되어야 함', () => {
+    render(<ProgressBar current={5} capacity={20} />);
+
+    const progressBar = screen.getByRole('progressbar');
+    const progressBarFill = screen.getByRole('presentation');
+
+    expect(progressBar).toBeInTheDocument();
+    expect(progressBarFill).toBeInTheDocument();
+  });
+
+  it('className prop이 적용되어야 함', () => {
+    render(<ProgressBar current={5} capacity={20} className="custom-class" />);
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveClass('custom-class');
+  });
+
+  it('barClassName prop이 적용되어야 함', () => {
+    render(
+      <ProgressBar current={5} capacity={20} barClassName="custom-bar-class" />,
+    );
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill).toHaveClass('custom-bar-class');
+  });
+
+  it('진행률이 100%를 초과하지 않아야 함', () => {
+    render(<ProgressBar current={25} capacity={20} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill.style.width).toBe('100%');
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('current나 capacity가 유효하지 않은 경우 0%로 표시되어야 함', () => {
+    render(<ProgressBar current={NaN} capacity={20} />);
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill.style.width).toBe('0%');
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('정확한 진행률이 계산되어야 함', () => {
+    render(<ProgressBar current={5} capacity={20} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill.style.width).toBe('25%');
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '25');
+  });
+
+  it('0% 진행률이 정상적으로 표시되어야 함', () => {
+    render(<ProgressBar current={0} capacity={20} />);
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill.style.width).toBe('0%');
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('capacity가 0인 경우 0%로 표시되어야 함', () => {
+    render(<ProgressBar current={5} capacity={0} />);
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill.style.width).toBe('0%');
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('barClassName으로 bg-orange-400이 전달되면 적용되어야 함', () => {
+    render(
+      <ProgressBar current={5} capacity={20} barClassName="bg-orange-400" />,
+    );
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill).toHaveClass('bg-orange-400');
+  });
+
+  it('barClassName으로 bg-orange-400이 전달되어도 다른 기본 스타일은 유지되어야 함', () => {
+    render(
+      <ProgressBar current={5} capacity={20} barClassName="bg-orange-400" />,
+    );
+
+    const progressBarFill = screen.getByRole('presentation');
+    expect(progressBarFill).toHaveClass(
+      'h-1',
+      'rounded-md',
+      'transition-all',
+      'duration-1000',
+      'ease-out',
+    );
+  });
+});

--- a/src/components/common/progress-bar.tsx
+++ b/src/components/common/progress-bar.tsx
@@ -44,6 +44,7 @@ export default function ProgressBar({
       className={cn(`relative h-1 w-full rounded-md bg-orange-50`, className)}
     >
       <div
+        role="presentation"
         className={cn(
           `h-1 rounded-md bg-orange-600 transition-all duration-1000 ease-out`,
           barClassName,

--- a/src/components/common/tag.test.tsx
+++ b/src/components/common/tag.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+
+import Tag from '~/src/components/common/tag';
+
+describe('Tag 컴포넌트', () => {
+  // 이렇게 구체적인 클래스명 말고 다른 구분 방법 찾아보기
+  it('small 사이즈로 렌더링되어야 함', () => {
+    render(<Tag size="small">테스트</Tag>);
+
+    const tag = screen.getByText('테스트');
+    expect(tag).toHaveClass('pr-4');
+    expect(tag).toHaveClass('rounded-tr-[22px]');
+  });
+
+  it('large 사이즈로 렌더링되어야 함', () => {
+    render(<Tag size="large">테스트</Tag>);
+
+    const tag = screen.getByText('테스트');
+    expect(tag).toHaveClass('pr-2.5');
+  });
+
+  it('children이 렌더링되어야 함', () => {
+    render(<Tag size="small">테스트 텍스트</Tag>);
+    expect(screen.getByText('테스트 텍스트')).toBeInTheDocument();
+  });
+});

--- a/src/components/gathering-card/chip-info-container.test.tsx
+++ b/src/components/gathering-card/chip-info-container.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+
+import ChipInfoContainer from './chip-info-container';
+
+describe('ChipInfoContainer', () => {
+  const mockDateTime = '2024-03-20T14:30:00';
+
+  it('날짜와 시간이 올바르게 표시되는지 확인', () => {
+    render(<ChipInfoContainer dateTime={mockDateTime} />);
+
+    expect(screen.getByText('3월 20일')).toBeInTheDocument();
+    expect(screen.getByText('14:30')).toBeInTheDocument();
+  });
+
+  it('추가 className이 적용되는지 확인', () => {
+    const customClassName = 'custom-class';
+    const { container } = render(
+      <ChipInfoContainer dateTime={mockDateTime} className={customClassName} />,
+    );
+
+    expect(container.firstChild).toHaveClass('flex gap-2', customClassName);
+  });
+
+  it('날짜와 시간 칩이 올바르게 렌더링되는지 확인', () => {
+    render(<ChipInfoContainer dateTime={mockDateTime} />);
+
+    const dateChip = screen.getByText('3월 20일');
+    const timeChip = screen.getByText('14:30');
+
+    expect(dateChip).toHaveClass('text-white');
+    expect(timeChip).toHaveClass('text-orange-600');
+  });
+});

--- a/src/components/gathering-card/chip-info-container.test.tsx
+++ b/src/components/gathering-card/chip-info-container.test.tsx
@@ -3,13 +3,13 @@ import { render, screen } from '@testing-library/react';
 import ChipInfoContainer from './chip-info-container';
 
 describe('ChipInfoContainer', () => {
-  const mockDateTime = '2024-03-20T14:30:00';
+  const mockDateTime = '2024-03-20T14:30:00Z';
 
   it('날짜와 시간이 올바르게 표시되는지 확인', () => {
     render(<ChipInfoContainer dateTime={mockDateTime} />);
 
     expect(screen.getByText('3월 20일')).toBeInTheDocument();
-    expect(screen.getByText('14:30')).toBeInTheDocument();
+    expect(screen.getByText('23:30')).toBeInTheDocument();
   });
 
   it('추가 className이 적용되는지 확인', () => {
@@ -25,9 +25,17 @@ describe('ChipInfoContainer', () => {
     render(<ChipInfoContainer dateTime={mockDateTime} />);
 
     const dateChip = screen.getByText('3월 20일');
-    const timeChip = screen.getByText('14:30');
+    const timeChip = screen.getByText('23:30');
 
     expect(dateChip).toHaveClass('text-white');
     expect(timeChip).toHaveClass('text-orange-600');
+  });
+
+  it('시간대 정보가 없는 날짜와 시간이 올바르게 표시되는지 확인', () => {
+    const mockDateTimeWithoutZone = '2024-03-20T14:30:00'; // 시간대 정보 없음
+    render(<ChipInfoContainer dateTime={mockDateTimeWithoutZone} />);
+
+    expect(screen.getByText('3월 20일')).toBeInTheDocument();
+    expect(screen.getByText('14:30')).toBeInTheDocument(); // 한국 시간으로 간주
   });
 });

--- a/src/components/gathering-card/closed-button.test.tsx
+++ b/src/components/gathering-card/closed-button.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import ClosedButton from '~/src/components/gathering-card/closed-button';
+
+describe('ClosedButton', () => {
+  it('버튼이 올바르게 렌더링되어야 합니다', () => {
+    render(<ClosedButton />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Closed');
+  });
+});

--- a/src/components/gathering-card/confirmation.test.tsx
+++ b/src/components/gathering-card/confirmation.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+
+import Confirmation from '~/src/components/gathering-card/confirmation';
+
+describe('Confirmation', () => {
+  it('renders confirmation message', () => {
+    render(<Confirmation />);
+    expect(screen.getByText('개설확정')).toBeInTheDocument();
+  });
+});

--- a/src/components/gathering-card/gathering-card-large.test.skip.tsx
+++ b/src/components/gathering-card/gathering-card-large.test.skip.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { type Gathering } from '~/src/services/gatherings/types';
+
+import GatheringCardLarge from './gathering-card-large';
+
+const MOCK_GATHERING: Gathering = {
+  id: 1,
+  type: 'DALLAEMFIT',
+  name: '테스트 모임',
+  dateTime: '2024-12-31T14:00:00',
+  registrationEnd: '2024-12-30T23:59:59',
+  location: '건대입구',
+  capacity: 20,
+  participantCount: 5,
+  image: 'https://picsum.photos/400?random=1',
+  createdBy: 1,
+  canceledAt: null,
+};
+
+describe('GatheringCardLarge 컴포넌트', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('기본 정보가 올바르게 렌더링되어야 함', () => {
+    render(<GatheringCardLarge gathering={MOCK_GATHERING} />);
+
+    expect(screen.getByText(MOCK_GATHERING.name)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_GATHERING.location)).toBeInTheDocument();
+  });
+
+  it('참가자 수와 정원이 올바르게 표시되어야 함', () => {
+    render(<GatheringCardLarge gathering={MOCK_GATHERING} />);
+
+    expect(
+      screen.getByText(
+        `${MOCK_GATHERING.participantCount}/${MOCK_GATHERING.capacity}명`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('마감된 모임의 경우 마감 메시지가 표시되어야 함', () => {
+    const closedGathering = {
+      ...MOCK_GATHERING,
+      registrationEnd: '2023-01-01T00:00:00', // 과거 날짜
+    };
+
+    render(<GatheringCardLarge gathering={closedGathering} />);
+
+    expect(screen.getByText('마감된 챌린지예요,')).toBeInTheDocument();
+    expect(screen.getByText('다음 기회에 만나요🙏')).toBeInTheDocument();
+  });
+
+  it('오늘 마감되는 모임의 경우 마감 시간 태그가 표시되어야 함', () => {
+    const today = new Date();
+    const todayEnd = new Date(today.setHours(20, 0, 0, 0)).toISOString();
+
+    const todayClosingGathering = {
+      ...MOCK_GATHERING,
+      registrationEnd: todayEnd,
+    };
+
+    render(<GatheringCardLarge gathering={todayClosingGathering} />);
+
+    expect(screen.getByText(/오늘.*마감/)).toBeInTheDocument();
+  });
+
+  describe('찜하기 기능', () => {
+    it('찜하기 버튼을 클릭하면 localStorage에 저장되어야 함', async () => {
+      render(<GatheringCardLarge gathering={MOCK_GATHERING} />);
+      const user = userEvent.setup();
+
+      // Save 아이콘 찾기
+      const saveButton = screen.getByRole('button', { name: '찜하기' });
+
+      // 클릭 전 localStorage 확인
+      expect(JSON.parse(localStorage.getItem('wishlist') || '[]')).toHaveLength(
+        0,
+      );
+
+      // 버튼 클릭
+      await user.click(saveButton);
+
+      // localStorage에 저장되었는지 확인
+      const wishlist = JSON.parse(localStorage.getItem('wishlist') || '[]');
+      expect(wishlist).toContain(MOCK_GATHERING.id);
+    });
+
+    it('이미 찜한 모임은 다시 클릭하면 localStorage에서 제거되어야 함', async () => {
+      // 미리 localStorage에 찜하기 데이터 설정
+      localStorage.setItem('wishlist', JSON.stringify([MOCK_GATHERING.id]));
+
+      render(<GatheringCardLarge gathering={MOCK_GATHERING} />);
+      const user = userEvent.setup();
+
+      const saveButton = screen.getByRole('button', { name: '찜하기' });
+
+      // 클릭 전에는 찜한 상태
+      expect(JSON.parse(localStorage.getItem('wishlist') || '[]')).toContain(
+        MOCK_GATHERING.id,
+      );
+
+      // 버튼 클릭
+      await user.click(saveButton);
+
+      // localStorage에서 제거되었는지 확인
+      const wishlist = JSON.parse(localStorage.getItem('wishlist') || '[]');
+      expect(wishlist).not.toContain(MOCK_GATHERING.id);
+    });
+
+    it('이미 찜된 마감 모임은 찜 취소 후 버튼이 사라져야 함', async () => {
+      const closedGathering = {
+        ...MOCK_GATHERING,
+        registrationEnd: '2023-01-01T00:00:00',
+      };
+
+      localStorage.setItem('wishlist', JSON.stringify([closedGathering.id]));
+
+      render(<GatheringCardLarge gathering={closedGathering} />);
+      const user = userEvent.setup();
+
+      // 초기에는 SaveBye 버튼이 존재
+      const saveButton = screen.getByTestId('mock-svg');
+      expect(saveButton).toBeInTheDocument();
+
+      // 찜 취소
+      await user.click(saveButton);
+
+      // localStorage에서 제거되었는지 확인
+      const wishlist = JSON.parse(localStorage.getItem('wishlist') || '[]');
+      expect(wishlist).not.toContain(closedGathering.id);
+
+      // 버튼이 사라졌는지 확인
+      expect(screen.queryByTestId('mock-svg')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/gathering-card/gathering-detail-content.tsx
+++ b/src/components/gathering-card/gathering-detail-content.tsx
@@ -16,7 +16,6 @@ export default function GatheringDetailContent({ gatheringId }: Props) {
   if (isLoading) return <Loading />;
   if (isError) return <div>에러가 발생했습니다.</div>;
   if (!data) return null;
-  console.log(data);
 
   return (
     <>

--- a/src/components/gathering-card/gathering-detail-content.tsx
+++ b/src/components/gathering-card/gathering-detail-content.tsx
@@ -16,6 +16,7 @@ export default function GatheringDetailContent({ gatheringId }: Props) {
   if (isLoading) return <Loading />;
   if (isError) return <div>에러가 발생했습니다.</div>;
   if (!data) return null;
+  console.log(data);
 
   return (
     <>

--- a/src/components/gathering-card/gathering-info.tsx
+++ b/src/components/gathering-card/gathering-info.tsx
@@ -15,8 +15,8 @@ interface GatheringInfoProps {
 
 export default function GatheringInfo({ gathering }: GatheringInfoProps) {
   const { isSaved, handleSaveButton } = useGatheringCard({
-    participantCount: gathering.participantCount ?? 5,
-    capacity: gathering.capacity ?? 20,
+    participantCount: gathering.participantCount,
+    capacity: gathering.capacity,
     gatheringId: gathering.id,
   });
 
@@ -30,13 +30,11 @@ export default function GatheringInfo({ gathering }: GatheringInfoProps) {
         {/* 위 */}
         <div className="flex justify-between px-6">
           <div className="flex flex-col">
-            <span className="text-lg font-semibold">
-              {gathering.name ?? '모임제목정도는좀써주지'}
-            </span>
+            <span className="text-lg font-semibold">{gathering.name}</span>
             <span className="mb-3 mt-0.5 text-sm font-medium text-gray-700">
               {gathering.location}
             </span>
-            <ChipInfoContainer dateTime={gathering.dateTime ?? ''} />
+            <ChipInfoContainer dateTime={gathering.dateTime} />
           </div>
           <div className="">
             <Save
@@ -67,8 +65,8 @@ export default function GatheringInfo({ gathering }: GatheringInfoProps) {
             {gathering.participantCount >= 5 && <Confirmation />}
           </div>
           <ProgressBar
-            current={gathering.participantCount || 5}
-            capacity={gathering.capacity || 20}
+            current={gathering.participantCount}
+            capacity={gathering.capacity}
             className="mb-2 mt-3"
             barClassName={`${gathering.participantCount >= gathering.capacity && 'bg-orange-400'}`}
           />

--- a/src/components/gathering-card/join-now-button.test.tsx
+++ b/src/components/gathering-card/join-now-button.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import JoinNowButton from '~/src/components/gathering-card/join-now-button';
+
+describe('JoinNowButton', () => {
+  it('버튼이 올바르게 렌더링되어야 합니다', () => {
+    render(<JoinNowButton />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('join now');
+  });
+});

--- a/src/hooks/gatherings/use-count-animation.test.skip.ts
+++ b/src/hooks/gatherings/use-count-animation.test.skip.ts
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useCountAnimation } from './use-count-animation';
+
+describe('useCountAnimation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('초기 카운트는 0이어야 함', () => {
+    const { result } = renderHook(() => useCountAnimation(10));
+    expect(result.current).toBe(0);
+  });
+
+  it('cleanup이 제대로 동작해야 함', () => {
+    const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+    const { unmount } = renderHook(() => useCountAnimation(10));
+
+    act(() => {
+      unmount();
+    });
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/src/hooks/gatherings/use-count-animation.ts
+++ b/src/hooks/gatherings/use-count-animation.ts
@@ -7,23 +7,28 @@ export function useCountAnimation(
   const [count, setCount] = useState(0);
 
   useEffect(() => {
-    let startTime: number;
-    let animationFrame: number;
+    let startTime: number | null = null;
+    let timeoutId: NodeJS.Timeout;
 
-    const animate = (currentTime: number) => {
+    const animate = () => {
+      const currentTime = performance.now();
       if (!startTime) startTime = currentTime;
-      const progress = (currentTime - startTime) / duration;
+
+      const progress = Math.min((currentTime - startTime) / duration, 1);
 
       if (progress < 1) {
         setCount(Math.floor(targetValue * progress));
-        animationFrame = requestAnimationFrame(animate);
+        timeoutId = setTimeout(animate, 16);
       } else {
         setCount(targetValue);
       }
     };
 
-    animationFrame = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(animationFrame);
+    setCount(0);
+    startTime = null;
+    timeoutId = setTimeout(animate, 16);
+
+    return () => clearTimeout(timeoutId);
   }, [targetValue, duration]);
 
   return count;

--- a/src/hooks/gatherings/use-gathering-card.test.ts
+++ b/src/hooks/gatherings/use-gathering-card.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from '@testing-library/react';
+
+import useGatheringCard from './use-gathering-card';
+
+describe('useGatheringCard 훅', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('초기 상태가 올바르게 설정되어야 함', () => {
+    const { result } = renderHook(() =>
+      useGatheringCard({
+        gatheringId: 1,
+        participantCount: 3,
+        capacity: 10,
+      }),
+    );
+
+    expect(result.current.isSaved).toBe(false);
+    expect(result.current.cardState).toBe('ongoing');
+  });
+
+  it('참가자 수에 따라 cardState가 올바르게 변경되어야 함', () => {
+    const { result, rerender } = renderHook(
+      ({ participantCount }) =>
+        useGatheringCard({
+          gatheringId: 1,
+          participantCount,
+          capacity: 10,
+        }),
+      { initialProps: { participantCount: 3 } },
+    );
+
+    expect(result.current.cardState).toBe('ongoing');
+
+    rerender({ participantCount: 6 });
+    expect(result.current.cardState).toBe('confirmation');
+
+    rerender({ participantCount: 10 });
+    expect(result.current.cardState).toBe('closed');
+  });
+
+  it('찜하기 버튼이 로컬스토리지를 올바르게 업데이트해야 함', () => {
+    const { result } = renderHook(() =>
+      useGatheringCard({
+        gatheringId: 1,
+        participantCount: 3,
+        capacity: 10,
+      }),
+    );
+
+    const mockEvent = {
+      stopPropagation: jest.fn(),
+    } as unknown as React.MouseEvent<SVGSVGElement>;
+
+    act(() => {
+      result.current.handleSaveButton(1)(mockEvent);
+    });
+
+    expect(result.current.isSaved).toBe(true);
+    expect(JSON.parse(localStorage.getItem('wishlist') || '[]')).toContain(1);
+
+    act(() => {
+      result.current.handleSaveButton(1)(mockEvent);
+    });
+
+    expect(result.current.isSaved).toBe(false);
+    expect(JSON.parse(localStorage.getItem('wishlist') || '[]')).not.toContain(
+      1,
+    );
+  });
+});

--- a/src/mocks/fileMock.js
+++ b/src/mocks/fileMock.js
@@ -1,0 +1,2 @@
+const fileStub = 'test-file-stub';
+export default fileStub;

--- a/src/mocks/svgrMock.js
+++ b/src/mocks/svgrMock.js
@@ -1,0 +1,3 @@
+const svgMock = 'svg';
+export const ReactComponent = 'div';
+export default svgMock;

--- a/src/utils/format-date-time.test.ts
+++ b/src/utils/format-date-time.test.ts
@@ -33,4 +33,15 @@ describe('formatDateTime', () => {
     const result = formatDateTime(input);
     expect(result).toEqual(expectedOutput);
   });
+
+  it('시간대 정보가 없는 날짜와 시간을 한국 날짜 및 시간 형식으로 변환해야 합니다', () => {
+    const input = '2024-12-15T12:00:00'; // 시간대 정보 없음
+    const expectedOutput = {
+      date: '12월 15일',
+      time: '12:00', // 한국 시간으로 간주
+    };
+
+    const result = formatDateTime(input);
+    expect(result).toEqual(expectedOutput);
+  });
 });

--- a/src/utils/format-date-time.test.ts
+++ b/src/utils/format-date-time.test.ts
@@ -1,0 +1,36 @@
+import formatDateTime from './format-date-time';
+
+describe('formatDateTime', () => {
+  it('UTC 날짜와 시간을 한국 날짜 및 시간 형식으로 변환해야 합니다', () => {
+    const input = '2024-12-15T12:00:00.000Z';
+    const expectedOutput = {
+      date: '12월 15일',
+      time: '21:00', // 한국 시간으로 변환된 시간
+    };
+
+    const result = formatDateTime(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('자정 시간을 올바르게 처리해야 합니다', () => {
+    const input = '2024-12-15T15:00:00.000Z'; // UTC 15:00은 KST에서 자정
+    const expectedOutput = {
+      date: '12월 16일', // 날짜가 다음 날로 넘어감
+      time: '00:00',
+    };
+
+    const result = formatDateTime(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('이른 아침 시간을 올바르게 처리해야 합니다', () => {
+    const input = '2024-12-15T00:00:00.000Z'; // UTC 00:00은 KST에서 09:00
+    const expectedOutput = {
+      date: '12월 15일',
+      time: '09:00',
+    };
+
+    const result = formatDateTime(input);
+    expect(result).toEqual(expectedOutput);
+  });
+});

--- a/src/utils/format-date-time.test.ts
+++ b/src/utils/format-date-time.test.ts
@@ -44,4 +44,27 @@ describe('formatDateTime', () => {
     const result = formatDateTime(input);
     expect(result).toEqual(expectedOutput);
   });
+
+  // 추가: 다양한 시간대 정보가 없는 케이스
+  it('시간대 정보가 없는 다양한 시간을 처리해야 합니다', () => {
+    const testCases = [
+      {
+        input: '2024-12-15T00:00:00',
+        expected: { date: '12월 15일', time: '00:00' },
+      },
+      {
+        input: '2024-12-15T23:59:00',
+        expected: { date: '12월 15일', time: '23:59' },
+      },
+      {
+        input: '2024-12-15T09:30:00',
+        expected: { date: '12월 15일', time: '09:30' },
+      },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      const result = formatDateTime(input);
+      expect(result).toEqual(expected);
+    });
+  });
 });

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -1,18 +1,23 @@
+// dateTime 형식: "2024-12-15T12:00:00.000Z"
+// 한국 시간대로 변환 후 date와 time 형식 변환
+
 export default function formatDateTime(dateTime: string): {
   date: string;
   time: string;
 } {
-  // 시간이 없는 경우 '00:00:00'을 추가
-  const fullDateTime = dateTime.includes('T')
-    ? dateTime
-    : `${dateTime}T00:00:00`;
+  // 한국 시간대로 변환
+  const dateObj = new Date(dateTime); // dateTime을 Date 객체로 변환
 
-  const dateObj = new Date(fullDateTime);
+  // 한국 시간으로 변환하기 위해 UTC 시간에 9시간을 더함
+  const koreaTimeOffset = 9 * 60; // 9시간을 분으로 변환
+  const localDateObj = new Date(
+    dateObj.getTime() + koreaTimeOffset * 60 * 1000,
+  );
 
-  const month = dateObj.getMonth() + 1;
-  const day = dateObj.getDate();
-  const hours = dateObj.getHours();
-  const minutes = dateObj.getMinutes();
+  const month = localDateObj.getUTCMonth() + 1;
+  const day = localDateObj.getUTCDate();
+  const hours = localDateObj.getUTCHours();
+  const minutes = localDateObj.getUTCMinutes();
 
   // "1월 7일" 형식으로 변환
   const date = `${month}월 ${day}일`;

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -22,7 +22,7 @@ export default function formatDateTime(dateTime: string): {
     !dateTime.includes('+') &&
     !dateTime.includes('-')
   ) {
-    parsedDate = new Date(`${dateTime}Z`); // 한국 시간대로 간주하여 UTC로 변환
+    parsedDate = new Date(parsedDate.getTime() - 9 * 60 * 60 * 1000);
   }
 
   const localDateObj = toZonedTime(parsedDate, timeZone);

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -1,23 +1,36 @@
-// dateTime 형식: "2024-12-15T12:00:00.000Z"
-// 한국 시간대로 변환 후 date와 time 형식 변환
+/**
+ * dateTime 형식이 "2024-12-15T12:00:00.000Z" 일 때도 있고
+ * "2024-12-15T12:00:00" 일 때도 있는 것 같은데
+ * 후자처럼 시간대 정보가 없으면 한국 시간대라고 간주하고
+ * 전자처럼 시간대 정보가 있으면 한국 시간대로 변환
+ * 그 후에 date와 time 형식 분리
+ */
+
+import { parseISO } from 'date-fns';
+import { toZonedTime } from 'date-fns-tz';
 
 export default function formatDateTime(dateTime: string): {
   date: string;
   time: string;
 } {
-  // 한국 시간대로 변환
-  const dateObj = new Date(dateTime); // dateTime을 Date 객체로 변환
+  const timeZone = 'Asia/Seoul';
+  let parsedDate = parseISO(dateTime);
 
-  // 한국 시간으로 변환하기 위해 UTC 시간에 9시간을 더함
-  const koreaTimeOffset = 9 * 60; // 9시간을 분으로 변환
-  const localDateObj = new Date(
-    dateObj.getTime() + koreaTimeOffset * 60 * 1000,
-  );
+  // dateTime에 시간대 정보가 없을 경우 한국 시간대로 간주
+  if (
+    !dateTime.includes('Z') &&
+    !dateTime.includes('+') &&
+    !dateTime.includes('-')
+  ) {
+    parsedDate = new Date(`${dateTime}Z`); // 한국 시간대로 간주하여 UTC로 변환
+  }
 
-  const month = localDateObj.getUTCMonth() + 1;
-  const day = localDateObj.getUTCDate();
-  const hours = localDateObj.getUTCHours();
-  const minutes = localDateObj.getUTCMinutes();
+  const localDateObj = toZonedTime(parsedDate, timeZone);
+
+  const month = localDateObj.getMonth() + 1;
+  const day = localDateObj.getDate();
+  const hours = localDateObj.getHours();
+  const minutes = localDateObj.getMinutes();
 
   // "1월 7일" 형식으로 변환
   const date = `${month}월 ${day}일`;

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -16,26 +16,32 @@ export default function formatDateTime(dateTime: string): {
   const timeZone = 'Asia/Seoul';
   let parsedDate = parseISO(dateTime);
 
-  // dateTime에 시간대 정보가 없을 경우 한국 시간대로 간주
-  if (
-    !dateTime.includes('Z') &&
-    !dateTime.includes('+') &&
-    !dateTime.includes('-')
-  ) {
-    parsedDate = new Date(parsedDate.getTime() - 9 * 60 * 60 * 1000);
+  // 시간 부분에서만 시간대 정보를 찾도록 수정
+  const timezonePart = dateTime.split('T')[1];
+  const hasTimezoneInfo =
+    timezonePart.includes('Z') ||
+    timezonePart.includes('+') ||
+    timezonePart.includes('-');
+
+  if (!hasTimezoneInfo) {
+    console.log('Entering no timezone info branch');
+    parsedDate = new Date(
+      parsedDate.getFullYear(),
+      parsedDate.getMonth(),
+      parsedDate.getDate(),
+      parsedDate.getHours(),
+      parsedDate.getMinutes(),
+    );
+  } else {
+    parsedDate = toZonedTime(parsedDate, timeZone);
   }
 
-  const localDateObj = toZonedTime(parsedDate, timeZone);
+  const month = parsedDate.getMonth() + 1;
+  const day = parsedDate.getDate();
+  const hours = parsedDate.getHours();
+  const minutes = parsedDate.getMinutes();
 
-  const month = localDateObj.getMonth() + 1;
-  const day = localDateObj.getDate();
-  const hours = localDateObj.getHours();
-  const minutes = localDateObj.getMinutes();
-
-  // "1월 7일" 형식으로 변환
   const date = `${month}월 ${day}일`;
-
-  // "17:00" 형식으로 변환
   const time = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 
   return { date, time };

--- a/src/utils/is-registration-ended.test.ts
+++ b/src/utils/is-registration-ended.test.ts
@@ -1,4 +1,4 @@
-import { isRegistrationEnded } from './is-registration-ended';
+import { isRegistrationEnded } from '~/src/utils/is-registration-ended';
 
 describe('isRegistrationEnded', () => {
   beforeEach(() => {

--- a/src/utils/is-registration-ended.test.ts
+++ b/src/utils/is-registration-ended.test.ts
@@ -1,0 +1,27 @@
+import { isRegistrationEnded } from './is-registration-ended';
+
+describe('isRegistrationEnded', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:00'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('마감 기한이 지난 경우 true를 반환해야 함', () => {
+    const pastDate = '2023-12-31T23:59:59';
+    expect(isRegistrationEnded(pastDate)).toBe(true);
+  });
+
+  it('마감 기한이 아직 안 지난 경우 false를 반환해야 함', () => {
+    const futureDate = '2024-01-01T00:00:01';
+    expect(isRegistrationEnded(futureDate)).toBe(false);
+  });
+
+  it('마감 기한이 현재와 정확히 같은 경우 true를 반환해야 함', () => {
+    const currentDate = '2024-01-01T00:00:00';
+    expect(isRegistrationEnded(currentDate)).toBe(true);
+  });
+});

--- a/src/utils/is-registration-ended.ts
+++ b/src/utils/is-registration-ended.ts
@@ -3,5 +3,5 @@
 export function isRegistrationEnded(registrationEnd: string): boolean {
   const endDate = new Date(registrationEnd);
   const now = new Date();
-  return endDate < now;
+  return endDate <= now;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,9 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "src/mocks/svgrMock.js",
+    "src/mocks/fileMock.js"
   ],
   "exclude": ["node_modules", "cypress.config.ts"]
 }


### PR DESCRIPTION
resolves #112

## 🤔 해결하려는 문제가 무엇인가요?
- 테스트 시 jest가 svg와 이미지를 렌더링하지 못하는 문제: 전역 설정 추가로 테스트 실행 시 모든 svg와 이미지를 mock데이터로 대체하게 함. 
- 테스트 시 라우터 모킹 설정 추가
- progress bar 등 디폴트값 제거 
- formatDateTime 함수가 데이터를 한국 시간대 기준으로 처리하도록 수정.
- 현재 시각과 마감 시각이 정확히 같을 때 마감 true로 수정.

## 🎉 변경 사항


## 🙏 여기는 꼭 봐주세요!
- 라이브러리 2개 새로 설치했으니 `npm install` 해주세요 
  - "@testing-library/user-event" : 클릭 등 유저의 동작을 테스트하는 라이브러리
  - "date-fns-tz": 시간대 처리 도와주는 라이브러리
- "정확히 특정 svg/이미지가 맞게 렌더링되었는가?" 를 확인하려면 거기에 date-testid 넣고 그걸로 확인하는 방법밖에 없다네요. 
  - 그러니 조건부로 다른 svg 가져와야 한다든가 하는 상황 아니면 굳이 테스트 안 해도 된대요 주강사님이 
- `.skip`이 포함된 파일은 테스트 시 무시됩니다. 아직 덜 돼서 skip해둔 파일이 2개 있습니다. 

