### PR TITLE
드롭다운 이슈 수정

### DIFF
--- a/src/components/common/calendar-dropdown.tsx
+++ b/src/components/common/calendar-dropdown.tsx
@@ -65,6 +65,8 @@ export default function CalendarDown({
       ref={calendarRef}
       className={cn(
         'absolute z-50 mt-2 flex w-[336px] flex-col gap-3 rounded-xl border-[1px] border-secondary-200 bg-white px-[43px] py-6 shadow-xl',
+        'tablet:left-auto',
+        'left-1/2 -translate-x-[calc(50%+4px)] transform tablet:transform-none',
         className,
       )}
     >

--- a/src/components/common/profile-dropdown.tsx
+++ b/src/components/common/profile-dropdown.tsx
@@ -24,7 +24,7 @@ export default function ProfileDropdown() {
   const [user] = useAtom(userInfoAtom);
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState('');
+  // const [selectedOption, setSelectedOption] = useState('');
   const { mutate: logout } = useLogout();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const toggleDropdown = () => {
@@ -32,7 +32,7 @@ export default function ProfileDropdown() {
   };
 
   const handleSelect = (option: string) => {
-    setSelectedOption(option);
+    // setSelectedOption(option);
     if (option === '로그아웃') {
       setIsDialogOpen(true);
     } else if (option === '마이페이지') {
@@ -63,7 +63,7 @@ export default function ProfileDropdown() {
           options={['마이페이지', '로그아웃']}
           onSelect={handleSelect}
           version="Login"
-          selectedOption={selectedOption}
+          selectedOption=""
           onClose={() => setIsOpen(false)}
         />
       )}


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
캘린더 드롭다운의 모바일일 때의 위치 조정과 gnb에 있는 프로필 눌렀을 때의 드롭 다운이 선택되었을 때 기록이 남는 이슈 해결

## 🎉 변경 사항

- 캘린더 드롭다운은 모바일 일때만 {{필터의 길이} + {두 필터 사이의 gap}}/2만큼 왼쪽으로 이동시켰습니다.
- 프로필 드롭다운은 selectedoption을 사용해서 기록이 남는 것이기에 이원님이 만드신 프로필드롭다운에서 selectedoption을 주석처리했습니다.

## 🙏 여기는 꼭 봐주세요!
![ani4](https://github.com/user-attachments/assets/b95705f1-8beb-4a2f-8bd1-35eb2c7aa124)
![스크린샷 2024-12-14 231335](https://github.com/user-attachments/assets/9959aad0-ac94-4b61-97e1-f6354601de69)

