### PR TITLE
fix: 한국 시간대로 고정

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "axios": "^1.7.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "date-fns-tz": "^3.2.0",
     "jotai": "^2.10.3",
     "js-cookie": "^3.0.5",
     "next": "14.2.18",

--- a/src/components/gathering-card/chip-info-container.test.tsx
+++ b/src/components/gathering-card/chip-info-container.test.tsx
@@ -9,7 +9,7 @@ describe('ChipInfoContainer', () => {
     render(<ChipInfoContainer dateTime={mockDateTime} />);
 
     expect(screen.getByText('3월 20일')).toBeInTheDocument();
-    expect(screen.getByText('23:30')).toBeInTheDocument();
+    expect(screen.getByText('14:30')).toBeInTheDocument();
   });
 
   it('추가 className이 적용되는지 확인', () => {
@@ -25,7 +25,7 @@ describe('ChipInfoContainer', () => {
     render(<ChipInfoContainer dateTime={mockDateTime} />);
 
     const dateChip = screen.getByText('3월 20일');
-    const timeChip = screen.getByText('23:30');
+    const timeChip = screen.getByText('14:30');
 
     expect(dateChip).toHaveClass('text-white');
     expect(timeChip).toHaveClass('text-orange-600');
@@ -37,5 +37,13 @@ describe('ChipInfoContainer', () => {
 
     expect(screen.getByText('3월 20일')).toBeInTheDocument();
     expect(screen.getByText('14:30')).toBeInTheDocument(); // 한국 시간으로 간주
+  });
+
+  it('한국 시간대 날짜와 시간이 올바르게 표시되는지 확인', () => {
+    const mockDateTimeWithoutZone = '2024-03-20T14:30:00+09:00';
+    render(<ChipInfoContainer dateTime={mockDateTimeWithoutZone} />);
+
+    expect(screen.getByText('3월 20일')).toBeInTheDocument();
+    expect(screen.getByText('14:30')).toBeInTheDocument();
   });
 });

--- a/src/components/gathering-card/gathering-card-large.tsx
+++ b/src/components/gathering-card/gathering-card-large.tsx
@@ -49,7 +49,7 @@ export default function GatheringCardLarge({
             src={gathering.image}
             alt="cat"
             fill
-            className="rounded-l-3xl"
+            className="rounded-l-3xl object-cover"
           />
         )}
 

--- a/src/components/gathering-card/gathering-card-small.tsx
+++ b/src/components/gathering-card/gathering-card-small.tsx
@@ -48,7 +48,7 @@ export default function GatheringCardSmall({
             src={gathering.image}
             alt="cat"
             fill
-            className="rounded-t-3xl"
+            className="rounded-t-3xl object-cover"
           />
         )}
 

--- a/src/components/gathering-card/gathering-detail-image.tsx
+++ b/src/components/gathering-card/gathering-detail-image.tsx
@@ -31,7 +31,12 @@ export default function GatheringDetailImage({
           마감
         </Tag>
       )}
-      <Image src={image} alt="gathering image" fill className="rounded-3xl" />
+      <Image
+        src={image}
+        alt="gathering image"
+        fill
+        className="rounded-3xl object-cover"
+      />
     </div>
   );
 }

--- a/src/components/gathering-card/gathering-profile-images.tsx
+++ b/src/components/gathering-card/gathering-profile-images.tsx
@@ -53,7 +53,7 @@ export default function GatheringProfileImages({
             alt={`Profile Image ${index + 1}`}
             width={29}
             height={29}
-            className="rounded-full"
+            className="rounded-full object-cover"
             style={{ aspectRatio: '1' }}
           />
         </div>
@@ -74,7 +74,7 @@ export default function GatheringProfileImages({
               alt={`Profile Image ${index + 1}`}
               width={29}
               height={29}
-              className="rounded-full"
+              className="rounded-full object-cover"
               style={{ aspectRatio: '1' }}
             />
             <span className="text-xs">{participant.name}</span>

--- a/src/mocks/faker/fake-gatherings.ts
+++ b/src/mocks/faker/fake-gatherings.ts
@@ -27,26 +27,48 @@ export default function makeFakeGatherings(
       type:
         type ??
         faker.helpers.arrayElement<GatheringType>([
-          'DALLAEMFIT',
           'OFFICE_STRETCHING',
           'MINDFULNESS',
           'WORKATION',
         ]),
-      name: faker.company.name(),
+      name: (() => {
+        const currentType =
+          type ??
+          faker.helpers.arrayElement<GatheringType>([
+            'OFFICE_STRETCHING',
+            'MINDFULNESS',
+            'WORKATION',
+            'DALLAEMFIT',
+          ]);
+
+        switch (currentType) {
+          case 'WORKATION':
+            return '워케이션';
+          case 'OFFICE_STRETCHING':
+            return '달램핏 오피스 스트레칭';
+          case 'MINDFULNESS':
+            return '달램핏 마인드풀니스';
+          case 'DALLAEMFIT':
+            return faker.helpers.arrayElement([
+              '달램핏 오피스 스트레칭',
+              '달램핏 마인드풀니스',
+            ]);
+          default:
+            return '워케이션';
+        }
+      })(),
       dateTime: date
-        ? `${date}T${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:00:00`
+        ? `${date}T${faker.number
+            .int({ min: 0, max: 23 })
+            .toString()
+            .padStart(2, '0')}:00:00+09:00`
         : (() => {
             const randomDate =
               faker.helpers.maybe(() => faker.date.future({ years: 1 }), {
                 probability: 0.7,
               }) ?? faker.date.past({ years: 1 });
 
-            const year = randomDate.getFullYear();
-            const month = String(randomDate.getMonth() + 1).padStart(2, '0');
-            const day = String(randomDate.getDate()).padStart(2, '0');
-            const hour = String(randomDate.getHours()).padStart(2, '0');
-
-            return `${year}-${month}-${day}T${hour}:00:00`;
+            return randomDate.toISOString();
           })(),
       // 20% 확률로 오늘 마감이게 함
       registrationEnd:

--- a/src/mocks/handler/gatherings.ts
+++ b/src/mocks/handler/gatherings.ts
@@ -18,7 +18,7 @@ export const gatheringsHandlers = [
   // 특정 Gathering 상세정보 API
   http.get(baseUrl(`/gatherings/:id`), (req) => {
     const { id } = req.params;
-    const gathering = makeFakeGatherings(1, Number(id));
+    const gathering = makeFakeGatherings(1, Number(id))[0];
     if (!gathering) {
       return HttpResponse.json(
         { error: `Gathering with ID ${id} not found` },
@@ -46,6 +46,44 @@ export const gatheringsHandlers = [
     // id 파라미터가 있는 경우 해당 id들의 모임만 반환
     if (ids?.length) {
       const gatherings = ids.map((id) => makeFakeGatherings(1, id, type)[0]);
+      return HttpResponse.json(gatherings);
+    }
+
+    // DALLAEMFIT인 경우 두 가지 타입의 모임을 모두 생성
+    if (type === 'DALLAEMFIT') {
+      const gatherings = [];
+      const halfLimit = Math.ceil(limit / 2);
+
+      // OFFICE_STRETCHING 모임 생성
+      gatherings.push(
+        ...Array.from(
+          { length: halfLimit },
+          (_, i) =>
+            makeFakeGatherings(
+              1,
+              i + 1,
+              'OFFICE_STRETCHING',
+              location,
+              date,
+            )[0],
+        ),
+      );
+
+      // MINDFULNESS 모임 생성
+      gatherings.push(
+        ...Array.from(
+          { length: limit - halfLimit },
+          (_, i) =>
+            makeFakeGatherings(
+              1,
+              halfLimit + i + 1,
+              'MINDFULNESS',
+              location,
+              date,
+            )[0],
+        ),
+      );
+
       return HttpResponse.json(gatherings);
     }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -30,7 +30,7 @@ export const getDateForFormData = (
   if (hour) {
     const formattedHour = hour.toString().padStart(2, '0');
     const formattedMinute = (minute || 0).toString().padStart(2, '0');
-    return `${formattedDate}T${formattedHour}:${formattedMinute}:00`;
+    return `${formattedDate}T${formattedHour}:${formattedMinute}:00+09:00`;
   }
 
   return formattedDate;

--- a/src/utils/format-date-time.test.ts
+++ b/src/utils/format-date-time.test.ts
@@ -1,11 +1,11 @@
-import formatDateTime from './format-date-time';
+import formatDateTime from '~/src/utils/format-date-time';
 
 describe('formatDateTime', () => {
-  it('UTC 날짜와 시간을 한국 날짜 및 시간 형식으로 변환해야 합니다', () => {
+  it('UTC 시간(Z)을 한국 시간으로 변환해야 합니다', () => {
     const input = '2024-12-15T12:00:00.000Z';
     const expectedOutput = {
       date: '12월 15일',
-      time: '21:00', // 한국 시간으로 변환된 시간
+      time: '12:00', // Z를 +09:00으로 변환
     };
 
     const result = formatDateTime(input);
@@ -13,9 +13,9 @@ describe('formatDateTime', () => {
   });
 
   it('자정 시간을 올바르게 처리해야 합니다', () => {
-    const input = '2024-12-15T15:00:00.000Z'; // UTC 15:00은 KST에서 자정
+    const input = '2024-12-15T00:00:00.000Z';
     const expectedOutput = {
-      date: '12월 16일', // 날짜가 다음 날로 넘어감
+      date: '12월 15일',
       time: '00:00',
     };
 
@@ -23,19 +23,8 @@ describe('formatDateTime', () => {
     expect(result).toEqual(expectedOutput);
   });
 
-  it('이른 아침 시간을 올바르게 처리해야 합니다', () => {
-    const input = '2024-12-15T00:00:00.000Z'; // UTC 00:00은 KST에서 09:00
-    const expectedOutput = {
-      date: '12월 15일',
-      time: '09:00',
-    };
-
-    const result = formatDateTime(input);
-    expect(result).toEqual(expectedOutput);
-  });
-
-  it('시간대 정보가 없는 날짜와 시간을 한국 날짜 및 시간 형식으로 변환해야 합니다', () => {
-    const input = '2024-12-15T12:00:00'; // 시간대 정보 없음
+  it('시간대 정보가 없는 날짜와 시간을 한국 시간으로 처리해야 합니다', () => {
+    const input = '2024-12-15T12:00:00';
     const expectedOutput = {
       date: '12월 15일',
       time: '12:00', // 한국 시간으로 간주
@@ -45,19 +34,29 @@ describe('formatDateTime', () => {
     expect(result).toEqual(expectedOutput);
   });
 
-  // 추가: 다양한 시간대 정보가 없는 케이스
-  it('시간대 정보가 없는 다양한 시간을 처리해야 합니다', () => {
+  it('이미 한국 시간대(+09:00)가 명시된 시간을 올바르게 처리해야 합니다', () => {
+    const input = '2024-12-15T12:00:00+09:00';
+    const expectedOutput = {
+      date: '12월 15일',
+      time: '12:00',
+    };
+
+    const result = formatDateTime(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('다양한 시간 형식을 처리해야 합니다', () => {
     const testCases = [
       {
         input: '2024-12-15T00:00:00',
         expected: { date: '12월 15일', time: '00:00' },
       },
       {
-        input: '2024-12-15T23:59:00',
+        input: '2024-12-15T23:59:00Z',
         expected: { date: '12월 15일', time: '23:59' },
       },
       {
-        input: '2024-12-15T09:30:00',
+        input: '2024-12-15T09:30:00+09:00',
         expected: { date: '12월 15일', time: '09:30' },
       },
     ];

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -1,27 +1,19 @@
-import { parseISO } from 'date-fns';
-
 export default function formatDateTime(dateTime: string): {
   date: string;
   time: string;
 } {
-  let normalizedDateTime = dateTime;
-  const [datePart, timePart] = dateTime.split('T');
+  // 시간 부분만 추출
+  const match = dateTime.match(/T(\d{2}):(\d{2})/);
+  if (!match) throw new Error('Invalid date time format');
 
-  if (timePart.includes('Z')) {
-    normalizedDateTime = `${datePart}T${timePart.replace('Z', '+09:00')}`;
-  } else if (!timePart.includes('+') && !timePart.includes('-')) {
-    normalizedDateTime = `${dateTime}+09:00`;
-  }
+  const hours = match[1];
+  const minutes = match[2];
 
-  const parsedDate = parseISO(normalizedDateTime);
+  // 날짜 부분 추출
+  const [, month, day] = dateTime.split('T')[0].split('-');
 
-  const month = parsedDate.getMonth() + 1;
-  const day = parsedDate.getDate();
-  const hours = parsedDate.getHours();
-  const minutes = parsedDate.getMinutes();
-
-  const date = `${month}월 ${day}일`;
-  const time = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-
-  return { date, time };
+  return {
+    date: `${Number(month)}월 ${Number(day)}일`,
+    time: `${hours}:${minutes}`,
+  };
 }

--- a/src/utils/format-date-time.ts
+++ b/src/utils/format-date-time.ts
@@ -1,40 +1,19 @@
-/**
- * dateTime 형식이 "2024-12-15T12:00:00.000Z" 일 때도 있고
- * "2024-12-15T12:00:00" 일 때도 있는 것 같은데
- * 후자처럼 시간대 정보가 없으면 한국 시간대라고 간주하고
- * 전자처럼 시간대 정보가 있으면 한국 시간대로 변환
- * 그 후에 date와 time 형식 분리
- */
-
 import { parseISO } from 'date-fns';
-import { toZonedTime } from 'date-fns-tz';
 
 export default function formatDateTime(dateTime: string): {
   date: string;
   time: string;
 } {
-  const timeZone = 'Asia/Seoul';
-  let parsedDate = parseISO(dateTime);
+  let normalizedDateTime = dateTime;
+  const [datePart, timePart] = dateTime.split('T');
 
-  // 시간 부분에서만 시간대 정보를 찾도록 수정
-  const timezonePart = dateTime.split('T')[1];
-  const hasTimezoneInfo =
-    timezonePart.includes('Z') ||
-    timezonePart.includes('+') ||
-    timezonePart.includes('-');
-
-  if (!hasTimezoneInfo) {
-    console.log('Entering no timezone info branch');
-    parsedDate = new Date(
-      parsedDate.getFullYear(),
-      parsedDate.getMonth(),
-      parsedDate.getDate(),
-      parsedDate.getHours(),
-      parsedDate.getMinutes(),
-    );
-  } else {
-    parsedDate = toZonedTime(parsedDate, timeZone);
+  if (timePart.includes('Z')) {
+    normalizedDateTime = `${datePart}T${timePart.replace('Z', '+09:00')}`;
+  } else if (!timePart.includes('+') && !timePart.includes('-')) {
+    normalizedDateTime = `${dateTime}+09:00`;
   }
+
+  const parsedDate = parseISO(normalizedDateTime);
 
   const month = parsedDate.getMonth() + 1;
   const day = parsedDate.getDate();


### PR DESCRIPTION
UTC 씹고 그냥 다 한국 시간대라고 가정
resolves #132

## 🤔 해결하려는 문제가 무엇인가요?
시간대 오류

## 🎉 변경 사항
서버에 한국 시간대로 입력
기존 데이터는 어쩔 수 없으니 어느 시간대 쓰든 그냥 한국 시간대라고 가정하고 처리

## 🙏 여기는 꼭 봐주세요!
date-fns-tz 라이브러리 오히려 방해가 되는 것 같아서 제거했습니다. 
사용하는 코드가 없으니 굳이 npm install 안 해도 에러가 나지는 않을걸요 
